### PR TITLE
[BXC-4242] Corrects Annotations + Unit Tests in Fixtures

### DIFF
--- a/fixtures/mini_annotations.json
+++ b/fixtures/mini_annotations.json
@@ -36,38 +36,38 @@
   },
   {
     "image": "http://localhost:8081/ncc/P0004_0483_17486.jpg",
-    "id": 2,
+    "id": 7,
     "label": [
       {
         "x": 0,
-        "y": 0,
+        "y": 86.89138576779023,
         "width": 100,
-        "height": 83.60128617363341,
-        "rotation": 0,
-        "rectanglelabels": [
-          "subject"
-        ],
-        "original_width": 1333,
-        "original_height": 1254
-      },
-      {
-        "x": 0,
-        "y": 84.2443729903537,
-        "width": 99.99999999999996,
-        "height": 15.755627009646291,
+        "height": 13.108614232209788,
         "rotation": 0,
         "rectanglelabels": [
           "color_bar"
         ],
         "original_width": 1333,
-        "original_height": 1254
+        "original_height": 1076
+      },
+      {
+        "x": 0.9063444108761332,
+        "y": 1.4981273408239701,
+        "width": 99.09365558912387,
+        "height": 85.0187265917603,
+        "rotation": 0,
+        "rectanglelabels": [
+          "subject"
+        ],
+        "original_width": 1333,
+        "original_height": 1076
       }
     ],
     "annotator": 1,
-    "annotation_id": 3,
-    "created_at": "2023-03-07T21:37:56.402245Z",
-    "updated_at": "2023-03-07T21:38:16.558772Z",
-    "lead_time": 59.888
+    "annotation_id": 8,
+    "created_at": "2023-03-07T21:42:19.765369Z",
+    "updated_at": "2023-03-07T21:42:19.765398Z",
+    "lead_time": 17.661
   },
   {
     "image": "http://localhost:8081/ncc/Cm912_1945u1_sheet1.jpg",
@@ -95,6 +95,20 @@
   {
     "image": "http://localhost:8081/ncc/G3902-F3-1981_U5_front.jpg",
     "id": 87,
+    "label": [
+      {
+        "x": 0,
+        "y": 0,
+        "width": 99.99999999999996,
+        "height": 100,
+        "rotation": 0,
+        "rectanglelabels": [
+          "subject"
+        ],
+        "original_width": 1333,
+        "original_height": 1031
+      }
+    ],
     "annotator": 1,
     "annotation_id": 88,
     "created_at": "2023-03-07T22:10:49.064903Z",

--- a/src/tests/test_image_augmentor.py
+++ b/src/tests/test_image_augmentor.py
@@ -137,7 +137,7 @@ class TestImageAugmentor:
     aug_annos = from_json(config.annotations_output_path)
     assert len(aug_annos) == 13 # 12 original + 1 augmented
     assert aug_annos[12]['image'] == str(output_path)
-    assert aug_annos[12]['annotation_id'] == 3
+    assert aug_annos[12]['annotation_id'] == 8
     assert sum(1 for x in config.output_base_path.rglob('*') if x.is_file()) == 1
     # Verify that augmented image was added to the file list output
     with open(config.file_list_output_path) as f:
@@ -158,7 +158,7 @@ class TestImageAugmentor:
     aug_annos = from_json(config.annotations_output_path)
     assert len(aug_annos) == 13 # 12 original + 1 augmented
     assert aug_annos[12]['image'] == str(output_path)
-    assert aug_annos[12]['annotation_id'] == 3
+    assert aug_annos[12]['annotation_id'] == 8
     assert sum(1 for x in config.output_base_path.rglob('*') if x.is_file()) == 1
 
   def test_process_image_twice(self, config, tmp_path):
@@ -177,7 +177,7 @@ class TestImageAugmentor:
     aug_annos = from_json(config.annotations_output_path)
     assert len(aug_annos) == 14 # 12 original + 2 augmented
     assert aug_annos[12]['image'] == str(output_path)
-    assert aug_annos[12]['annotation_id'] == 3
+    assert aug_annos[12]['annotation_id'] == 8
     assert aug_annos[13]['image'] == str(output_path2)
-    assert aug_annos[13]['annotation_id'] == 3
+    assert aug_annos[13]['annotation_id'] == 8
     assert sum(1 for x in config.output_base_path.rglob('*') if x.is_file()) == 2


### PR DESCRIPTION
Corrects P0004_0483_17486.jpg in the unit test fixtures against the production metadata in train_annotations.json, as the image metadata was swapped with that of another image.