### PR TITLE
[BXC-4242] Update data augmentation script to adjust bounding box coordinates

### DIFF
--- a/src/tests/test_image_augmentor.py
+++ b/src/tests/test_image_augmentor.py
@@ -132,6 +132,27 @@ class TestImageAugmentor:
       assert str(output_path) in lines
       assert len(lines) == 13
 
+  def test_label_augmentation(self, config, tmp_path):
+    # Seed guarantees correct selection
+    random.seed(42)
+    subject = ImageAugmentor(config)
+    output_path = subject.process(Path('fixtures/normalized_images/gilmer/00276_op0204_0001.jpg'))
+    subject.persist_annotations()
+    with Image.open(output_path) as aug_img:
+      assert (1276, 1333) == aug_img.size # Augmented image is rotated by 90
+      assert output_path.stem == '00276_op0204_0001_r90_s75' 
+    aug_annos = from_json(config.annotations_output_path)
+    assert len(aug_annos) == 13 # 12 original + 1 augmented
+    assert aug_annos[12]['image'] == str(output_path)
+    assert aug_annos[12]['rotation_type'] == 'r90'
+    assert len(aug_annos[12]['label']) == 2 #Subject, color_bar
+    assert aug_annos[12]['label'][0]['x'] == 0 
+    assert aug_annos[12]['label'][0]['y'] == 0
+    assert aug_annos[12]['label'][0]['width'] == 17.731629392971247
+    assert aug_annos[12]['label'][0]['height'] == 98.92966360856269
+    assert aug_annos[12]['label'][0]['original_width'] == 1276
+    assert aug_annos[12]['label'][0]['original_height'] == 1333
+
   def test_process_with_rotation_and_saturation(self, config, tmp_path):
     # Seed guarantees correct selection
     random.seed(42)
@@ -146,6 +167,9 @@ class TestImageAugmentor:
     assert len(aug_annos) == 13 # 12 original + 1 augmented
     assert aug_annos[12]['image'] == str(output_path)
     assert aug_annos[12]['annotation_id'] == 8
+    assert aug_annos[12]['rotation_type'] == 'r90'
+    assert aug_annos[12]['label'][0]['original_width'] == 1076 # Swap height and width from annotation
+    assert aug_annos[12]['label'][0]['original_height'] == 1333
     assert sum(1 for x in config.output_base_path.rglob('*') if x.is_file()) == 1
 
   def test_process_image_twice(self, config, tmp_path):
@@ -165,6 +189,8 @@ class TestImageAugmentor:
     assert len(aug_annos) == 14 # 12 original + 2 augmented
     assert aug_annos[12]['image'] == str(output_path)
     assert aug_annos[12]['annotation_id'] == 8
+    assert aug_annos[12]['rotation_type'] == 'r90'
     assert aug_annos[13]['image'] == str(output_path2)
     assert aug_annos[13]['annotation_id'] == 8
+    assert aug_annos[13]['rotation_type'] == 'r90fh'
     assert sum(1 for x in config.output_base_path.rglob('*') if x.is_file()) == 2

--- a/src/tests/test_image_augmentor.py
+++ b/src/tests/test_image_augmentor.py
@@ -72,19 +72,6 @@ class TestImageAugmentor:
       aug_data = np.array(aug_img)
       assert np.array_equal(np.flip(orig_data, 1), aug_data)
 
-  def test_aug_rotation_small_jitter(self, config):
-    # Seed guarantees correct rotation
-    random.seed(37)
-    subject = ImageAugmentor(config)
-    with Image.open('fixtures/normalized_images/ncc/P0004_0483_17486.jpg') as orig_img:
-      aug_img, rot_type = subject.aug_rotation(orig_img)
-      assert (1333, 1076) == aug_img.size
-      assert rot_type == 'rsmall'
-      # augmented image should be a little different from the originaly
-      orig_data = np.array(orig_img)
-      aug_data = np.array(aug_img)
-      assert not np.array_equal(orig_data, aug_data)
-
   def test_aug_saturation_reduce(self, config):
     # Seed guarantees correct selection
     random.seed(31)

--- a/src/utils/image_augmentor.py
+++ b/src/utils/image_augmentor.py
@@ -1,4 +1,4 @@
-from PIL import Image, ImageEnhance
+from PIL import Image, ImageEnhance, ImageDraw
 from pathlib import Path
 import random
 import logging
@@ -19,24 +19,83 @@ class ImageAugmentor:
     with Image.open(path) as img:
       img, rotate_type = self.aug_rotation(img)
       img, satur_type = self.aug_saturation(img)
-
+      logging.info(rotate_type)
       output_path = self.build_output_path(path, [rotate_type, satur_type])
+      logging.info(output_path)
       # skip saving file and adding annotation if one exists with the same name
       if str(output_path.resolve()) in self.path_to_anno:
         return output_path
       # construct path to write to, then save the file
       output_path.parent.mkdir(parents=True, exist_ok=True)
       img.save(output_path, "JPEG", optimize=True, quality=80)
-
-      self.add_aug_annotation(path, output_path)
       self.add_to_file_list(output_path)
       return output_path
 
-  def add_aug_annotation(self, orig_path, output_path):
+  def add_aug_annotation(self, orig_path, output_path, rotate_type):
     orig_anno = self.path_to_anno[str(orig_path.resolve())]
     aug_anno = copy.deepcopy(orig_anno)
     aug_anno['image'] = str(output_path)
+    # Original label coordinates are ...
+    # (x,y) (x + img_width * x, y)
+    # (x, y + img_height * height) (x + img_width *x, y + img_height * height)
+    for label in aug_anno['label']:
+      if 'color_bar' in label['rectanglelabels']:
+        # Compute dimensions required for all rotation types in pixels
+        orig_width = label['original_width']
+        orig_height = label['original_height']
+        orig_x = label["x"]/100.0 * orig_width
+        orig_y = label["y"]/100.0 * orig_height
+        label_width = label["width"]/100.0
+        label_height = label["height"]/100.0
+        bar_height = round(orig_height * label_height)
+        bar_width = round(orig_width * label_width)
+        if rotate_type=='r90':
+          # New top left coordinate is
+          # (y, img_width - (x + bar_width))
+          new_x = orig_y
+          new_y = orig_width - (orig_x + bar_width)
+          # Populate label
+          label["original_width"] = orig_height
+          label["original_height"] = orig_width
+          # Convert pixels to relative measurements
+          label["x"] = (new_x/orig_height) * 100
+          label["y"] = (new_y/orig_width) * 100
+          label["width"] = label_height * 100
+          label["height"] = label_width * 100
+        elif rotate_type=='rfv':
+          # (x, img_height - (y + bar_height)) ... (x + bar_width, img_height - (y + bar_height))
+          # (x, img_height - y)  ... (x + bar_width, img_height - y)
+          new_x = orig_x
+          new_y = orig_height - (orig_y + bar_height)
+          # Populate label
+          # Convert pixels to relative measurements, width and height remain unchanged
+          label["x"] = (new_x/orig_width) * 100
+          label["y"] = (new_y/orig_height) * 100
+        elif rotate_type == "rfh": 
+          # (img_width - (x + bar_width), y)  ... (img_width - x, y)
+          # (img_width - (x + bar_width), bar_height + y) ... (img_width - x, bar_height + y)
+          new_x = orig_width - (orig_x + bar_width)
+          new_y = orig_y
+          # Populate label
+          # Convert pixels to relative measurements, width and height remain unchanged
+          label["x"] = (new_x/orig_width) * 100
+          label["y"] = (new_y/orig_height) * 100
+        elif rotate_type == "r90fh":
+          # (img_height - (y + bar_height), img_width - (x + bar_width)) ... (img_height - y, img_width - (x + bar_width))
+          # (img_height - (y + bar_height), img_width - x) (img_height - y, img_width - x)
+          new_x = orig_height - (orig_y + bar_height)
+          new_y = orig_width - (orig_x + bar_width)
+          # Populate label
+          label["original_width"] = orig_height
+          label["original_height"] = orig_width
+          label["x"] = (new_x/orig_height) * 100
+          label["y"] = (new_y/orig_width) * 100
+          label["width"] = label_height * 100
+          label["height"] = label_width * 100
+    logging.debug(orig_anno)
+    logging.debug(aug_anno)
     self.annotations.append(aug_anno)
+    return img
 
   def init_file_list(self):
     if self.config.file_list_path.exists() and self.config.file_list_path != self.config.file_list_output_path:
@@ -70,7 +129,7 @@ class ImageAugmentor:
     return dest.with_name(f'{filename}_{"_".join(aug_types)}{path.suffix}')
 
   def aug_rotation(self, img):
-    index = random.randrange(0, 5)
+    index = random.randrange(0, 4)
     if index == 0:
       return img.rotate(90, expand=1), 'r90'
     elif index == 1:
@@ -79,8 +138,6 @@ class ImageAugmentor:
       return img.rotate(90, expand=1).transpose(Image.FLIP_LEFT_RIGHT), 'r90fh'
     elif index == 3:
       return img.transpose(Image.FLIP_LEFT_RIGHT), 'rfh'
-    else:
-      return img.rotate(random.randrange(1, 10)), 'rsmall'
 
   def aug_saturation(self, img):
     index = random.randrange(0, 10)

--- a/src/utils/image_augmentor.py
+++ b/src/utils/image_augmentor.py
@@ -46,6 +46,7 @@ class ImageAugmentor:
     aug_anno['image'] = str(output_path)
     aug_anno['rotation_type'] = rotate_type
     if 'label' not in aug_anno: # Some negative examples do not have labeled subject regions
+      self.annotations.append(aug_anno)
       return
     for label in aug_anno['label']:
       # Image width and height are measured in pixels

--- a/src/utils/image_augmentor.py
+++ b/src/utils/image_augmentor.py
@@ -1,6 +1,5 @@
 from PIL import Image, ImageEnhance
 import random
-import logging
 from src.utils.json_utils import from_json, to_json
 import copy
 import shutil
@@ -28,9 +27,7 @@ class ImageAugmentor:
     with Image.open(path) as img:
       img, rotate_type = self.aug_rotation(img)
       img, satur_type = self.aug_saturation(img)
-      logging.info(rotate_type)
       output_path = self.build_output_path(path, [rotate_type, satur_type])
-      logging.info(output_path)
       # skip saving file and adding annotation if one exists with the same name
       if str(output_path.resolve()) in self.path_to_anno:
         return output_path

--- a/src/utils/image_augmentor.py
+++ b/src/utils/image_augmentor.py
@@ -45,6 +45,8 @@ class ImageAugmentor:
     # Populate augmented annotation
     aug_anno['image'] = str(output_path)
     aug_anno['rotation_type'] = rotate_type
+    if 'label' not in aug_anno: # Some negative examples do not have labeled subject regions
+      return
     for label in aug_anno['label']:
       # Image width and height are measured in pixels
       # Bar dimensions and x, y coord are 0-100 relative to width, height


### PR DESCRIPTION
Populates labels for augmented images with x, y coordinates ([top-left corner relative to original_width and original_height](https://labelstud.io/tags/rectanglelabels.html)) for each rotation type in the image augmentor.  Adds new unit tests to confirm labels reflect any changes in dimensions after rotation or flipping.