### PR TITLE
BXC-4251 - Support resumption of classification

### DIFF
--- a/classify.py
+++ b/classify.py
@@ -14,6 +14,8 @@ parser.add_argument('-e', '--extensions', default='tif,tiff,jp2,jpg,jpf,jpx,png'
                     help='List of comma separated file extensions to filter by when operating on a directory. Default: tif,tiff,jp2,jpg,jpf,jpx,png'),
 parser.add_argument('-l', '--file-list', action="store_true",
                     help='If provided, then the src_path will be treated as a text file containing a list of newline separated paths to normalize.'),
+parser.add_argument('-r', '--restart', action="store_true",
+                    help='If provided, then the progress log will be discarded and processing will start from the beginning'),
 
 
 args = parser.parse_args()
@@ -44,5 +46,5 @@ elif args.src_path.is_dir():
 else:
   paths = [args.src_path]
 
-service = ClassifierWorkflowService(config, Path(args.report_path))
+service = ClassifierWorkflowService(config, Path(args.report_path), args.restart)
 service.process(paths)

--- a/classify.py
+++ b/classify.py
@@ -15,7 +15,7 @@ parser.add_argument('-e', '--extensions', default='tif,tiff,jp2,jpg,jpf,jpx,png'
 parser.add_argument('-l', '--file-list', action="store_true",
                     help='If provided, then the src_path will be treated as a text file containing a list of newline separated paths to normalize.'),
 parser.add_argument('-r', '--restart', action="store_true",
-                    help='If provided, then the progress log will be discarded and processing will start from the beginning'),
+                    help='If provided, then the progress log and CSV report will be discarded and processing will start from the beginning'),
 
 
 args = parser.parse_args()

--- a/src/tests/test_classifier_workflow_service.py
+++ b/src/tests/test_classifier_workflow_service.py
@@ -94,19 +94,23 @@ class TestClassifierWorkflowService:
     subject = ClassifierWorkflowService(config, report_path)
     subject.process(img_paths)
 
+    img_paths2 = [Path.cwd() / 'fixtures/normalized_images/ncc/G3902-F3-1981_U5_front.jpg',
+        Path.cwd() / 'fixtures/normalized_images/gilmer/00276_op0204_0001.jpg']
+
     subject2 = ClassifierWorkflowService(config, report_path, restart = True)
-    subject2.process(img_paths)
+    subject2.process(img_paths2)
 
     rows = self.load_csv_rows(report_path)
-    # Duplicate entry should be present, since we told it to restart the progress tracking
+    # After the restart, both entries should be present and the item that was previous first should be second to prove we didn't simply add to the CSV
     assert len(rows) == 3 # includes header row
-    self.assert_row_matches(rows[1], img_paths[0], config.output_base_path / 'gilmer/00276_op0204_0001.jpg', '1', 0.8863)
-    self.assert_row_matches(rows[2], img_paths[0], config.output_base_path / 'gilmer/00276_op0204_0001.jpg', '1', 0.8863)
+    self.assert_row_matches(rows[1], img_paths2[0], config.output_base_path / 'ncc/G3902-F3-1981_U5_front.jpg', '1', 0.9409)
+    self.assert_row_matches(rows[2], img_paths2[1], config.output_base_path / 'gilmer/00276_op0204_0001.jpg', '1', 0.8863)
 
-    # Progress log should only have the one entry since it got reset
+    # Progress log should have 2 items
     progress_list = self.load_progress_list(tmp_path)
-    assert progress_list[0] == str(img_paths[0])
-    assert len(progress_list) == 1
+    assert progress_list[0] == str(img_paths2[0])
+    assert progress_list[1] == str(img_paths2[1])
+    assert len(progress_list) == 2
 
   def assert_row_matches(self, row, exp_original_path, exp_norm_path, exp_class, exp_conf):
     assert row[0] == str(exp_original_path)

--- a/src/tests/test_classifier_workflow_service.py
+++ b/src/tests/test_classifier_workflow_service.py
@@ -14,6 +14,7 @@ def config(tmp_path):
   conf.src_base_path = Path.cwd() / 'fixtures/normalized_images/'
   conf.output_base_path = tmp_path / 'output'
   conf.output_base_path.mkdir(parents=True)
+  conf.progress_log_path = tmp_path / 'progress.log'
   conf.max_dimension = 256
   conf.min_dimension = 224
   conf.predict_rounding_threshold = 0.75
@@ -50,8 +51,82 @@ class TestClassifierWorkflowService:
     assert row[2] == exp_class
     # allow confidence to be within 5% of expected value, since the number isn't totally consistent across environments
     assert math.isclose(float(row[3]), exp_conf, rel_tol=0.05)
+    
+    rows = self.load_csv_rows(report_path)
+    assert rows[1] == [str(img_paths[0]), str(config.output_base_path / 'gilmer/00276_op0204_0001.jpg'), '1', '0.8863']
+    assert rows[2] == [str(img_paths[1]), str(config.output_base_path / 'ncc/G3902-F3-1981_U5_front.jpg'), '1', '0.9409']
+    assert rows[3] == [str(img_paths[2]), str(config.output_base_path / 'ncc/Cm912m_U58b9.jpg'), '1', '0.9775']
+    assert rows[4] == [str(img_paths[3]), str(config.output_base_path / 'ncc/fcpl_005.jpg'), '0', '0.6976']
+    assert len(rows) == 5 # includes header row
+
+  def test_with_resume(self, config, tmp_path):
+    torch.manual_seed(42) 
+    report_path = tmp_path / 'report.csv'
+    img_paths = [Path.cwd() / 'fixtures/normalized_images/gilmer/00276_op0204_0001.jpg',
+        Path.cwd() / 'fixtures/normalized_images/ncc/G3902-F3-1981_U5_front.jpg']
+
+    subject = ClassifierWorkflowService(config, report_path)
+    subject.process(img_paths)
+
+    rows = self.load_csv_rows(report_path)
+    assert rows[1] == [str(img_paths[0]), str(config.output_base_path / 'gilmer/00276_op0204_0001.jpg'), '1', '0.8863']
+    assert rows[2] == [str(img_paths[1]), str(config.output_base_path / 'ncc/G3902-F3-1981_U5_front.jpg'), '1', '0.9409']
+    assert len(rows) == 3 # includes header row
+
+    progress_list = self.load_progress_list(tmp_path)
+    assert progress_list[0] == str(img_paths[0])
+    assert progress_list[1] == str(img_paths[1])
+    assert len(progress_list) == 2
+
+    img_paths2 = [Path.cwd() / 'fixtures/normalized_images/gilmer/00276_op0204_0001.jpg',
+        Path.cwd() / 'fixtures/normalized_images/ncc/G3902-F3-1981_U5_front.jpg',
+        Path.cwd() / 'fixtures/normalized_images/ncc/Cm912m_U58b9.jpg',
+        Path.cwd() / 'fixtures/normalized_images/ncc/fcpl_005.jpg']
+
+    subject2 = ClassifierWorkflowService(config, report_path)
+    subject2.process(img_paths2)
+
+    rows = self.load_csv_rows(report_path)
+    assert rows[1] == [str(img_paths2[0]), str(config.output_base_path / 'gilmer/00276_op0204_0001.jpg'), '1', '0.8863']
+    assert rows[2] == [str(img_paths2[1]), str(config.output_base_path / 'ncc/G3902-F3-1981_U5_front.jpg'), '1', '0.9409']
+    assert rows[3] == [str(img_paths2[2]), str(config.output_base_path / 'ncc/Cm912m_U58b9.jpg'), '1', '0.9775']
+    assert rows[4] == [str(img_paths2[3]), str(config.output_base_path / 'ncc/fcpl_005.jpg'), '0', '0.6976']
+    assert len(rows) == 5 # includes header row
+
+    progress_list = self.load_progress_list(tmp_path)
+    assert progress_list[0] == str(img_paths2[0])
+    assert progress_list[1] == str(img_paths2[1])
+    assert progress_list[2] == str(img_paths2[2])
+    assert progress_list[3] == str(img_paths2[3])
+    assert len(progress_list) == 4
+
+  def test_restart(self, config, tmp_path):
+    torch.manual_seed(42) 
+    report_path = tmp_path / 'report.csv'
+    img_paths = [Path.cwd() / 'fixtures/normalized_images/gilmer/00276_op0204_0001.jpg']
+
+    subject = ClassifierWorkflowService(config, report_path)
+    subject.process(img_paths)
+
+    subject2 = ClassifierWorkflowService(config, report_path, restart = True)
+    subject2.process(img_paths)
+
+    rows = self.load_csv_rows(report_path)
+    # Duplicate entry should be present, since we told it to restart the progress tracking
+    assert len(rows) == 3 # includes header row
+    assert rows[1] == [str(img_paths[0]), str(config.output_base_path / 'gilmer/00276_op0204_0001.jpg'), '1', '0.8863']
+    assert rows[2] == [str(img_paths[0]), str(config.output_base_path / 'gilmer/00276_op0204_0001.jpg'), '1', '0.8863']
+
+    # Progress log should only have the one entry since it got reset
+    progress_list = self.load_progress_list(tmp_path)
+    assert progress_list[0] == str(img_paths[0])
+    assert len(progress_list) == 1
 
   def load_csv_rows(self, report_path):
     with open(report_path, 'r') as file:
       reader = csv.reader(file)
       return list(reader)
+
+  def load_progress_list(self, tmp_path):
+    with open(tmp_path / 'progress.log', 'r') as f:
+      return list(line for line in f.read().splitlines())

--- a/src/tests/test_classifier_workflow_service.py
+++ b/src/tests/test_classifier_workflow_service.py
@@ -45,20 +45,6 @@ class TestClassifierWorkflowService:
     self.assert_row_matches(rows[4], img_paths[3], config.output_base_path / 'ncc/fcpl_005.jpg', '0', 0.6976)
     assert len(rows) == 5 # includes header row
 
-  def assert_row_matches(self, row, exp_original_path, exp_norm_path, exp_class, exp_conf):
-    assert row[0] == str(exp_original_path)
-    assert row[1] == str(exp_norm_path)
-    assert row[2] == exp_class
-    # allow confidence to be within 5% of expected value, since the number isn't totally consistent across environments
-    assert math.isclose(float(row[3]), exp_conf, rel_tol=0.05)
-    
-    rows = self.load_csv_rows(report_path)
-    assert rows[1] == [str(img_paths[0]), str(config.output_base_path / 'gilmer/00276_op0204_0001.jpg'), '1', '0.8863']
-    assert rows[2] == [str(img_paths[1]), str(config.output_base_path / 'ncc/G3902-F3-1981_U5_front.jpg'), '1', '0.9409']
-    assert rows[3] == [str(img_paths[2]), str(config.output_base_path / 'ncc/Cm912m_U58b9.jpg'), '1', '0.9775']
-    assert rows[4] == [str(img_paths[3]), str(config.output_base_path / 'ncc/fcpl_005.jpg'), '0', '0.6976']
-    assert len(rows) == 5 # includes header row
-
   def test_with_resume(self, config, tmp_path):
     torch.manual_seed(42) 
     report_path = tmp_path / 'report.csv'
@@ -69,8 +55,8 @@ class TestClassifierWorkflowService:
     subject.process(img_paths)
 
     rows = self.load_csv_rows(report_path)
-    assert rows[1] == [str(img_paths[0]), str(config.output_base_path / 'gilmer/00276_op0204_0001.jpg'), '1', '0.8863']
-    assert rows[2] == [str(img_paths[1]), str(config.output_base_path / 'ncc/G3902-F3-1981_U5_front.jpg'), '1', '0.9409']
+    self.assert_row_matches(rows[1], img_paths[0], config.output_base_path / 'gilmer/00276_op0204_0001.jpg', '1', 0.8863)
+    self.assert_row_matches(rows[2], img_paths[1], config.output_base_path / 'ncc/G3902-F3-1981_U5_front.jpg', '1', 0.9409)
     assert len(rows) == 3 # includes header row
 
     progress_list = self.load_progress_list(tmp_path)
@@ -87,10 +73,10 @@ class TestClassifierWorkflowService:
     subject2.process(img_paths2)
 
     rows = self.load_csv_rows(report_path)
-    assert rows[1] == [str(img_paths2[0]), str(config.output_base_path / 'gilmer/00276_op0204_0001.jpg'), '1', '0.8863']
-    assert rows[2] == [str(img_paths2[1]), str(config.output_base_path / 'ncc/G3902-F3-1981_U5_front.jpg'), '1', '0.9409']
-    assert rows[3] == [str(img_paths2[2]), str(config.output_base_path / 'ncc/Cm912m_U58b9.jpg'), '1', '0.9775']
-    assert rows[4] == [str(img_paths2[3]), str(config.output_base_path / 'ncc/fcpl_005.jpg'), '0', '0.6976']
+    self.assert_row_matches(rows[1], img_paths2[0], config.output_base_path / 'gilmer/00276_op0204_0001.jpg', '1', 0.8863)
+    self.assert_row_matches(rows[2], img_paths2[1], config.output_base_path / 'ncc/G3902-F3-1981_U5_front.jpg', '1', 0.9409)
+    self.assert_row_matches(rows[3], img_paths2[2], config.output_base_path / 'ncc/Cm912m_U58b9.jpg', '1', 0.9775)
+    self.assert_row_matches(rows[4], img_paths2[3], config.output_base_path / 'ncc/fcpl_005.jpg', '0', 0.6976)
     assert len(rows) == 5 # includes header row
 
     progress_list = self.load_progress_list(tmp_path)
@@ -114,13 +100,20 @@ class TestClassifierWorkflowService:
     rows = self.load_csv_rows(report_path)
     # Duplicate entry should be present, since we told it to restart the progress tracking
     assert len(rows) == 3 # includes header row
-    assert rows[1] == [str(img_paths[0]), str(config.output_base_path / 'gilmer/00276_op0204_0001.jpg'), '1', '0.8863']
-    assert rows[2] == [str(img_paths[0]), str(config.output_base_path / 'gilmer/00276_op0204_0001.jpg'), '1', '0.8863']
+    self.assert_row_matches(rows[1], img_paths[0], config.output_base_path / 'gilmer/00276_op0204_0001.jpg', '1', 0.8863)
+    self.assert_row_matches(rows[2], img_paths[0], config.output_base_path / 'gilmer/00276_op0204_0001.jpg', '1', 0.8863)
 
     # Progress log should only have the one entry since it got reset
     progress_list = self.load_progress_list(tmp_path)
     assert progress_list[0] == str(img_paths[0])
     assert len(progress_list) == 1
+
+  def assert_row_matches(self, row, exp_original_path, exp_norm_path, exp_class, exp_conf):
+    assert row[0] == str(exp_original_path)
+    assert row[1] == str(exp_norm_path)
+    assert row[2] == exp_class
+    # allow confidence to be within 5% of expected value, since the number isn't totally consistent across environments
+    assert math.isclose(float(row[3]), exp_conf, rel_tol=0.05)
 
   def load_csv_rows(self, report_path):
     with open(report_path, 'r') as file:

--- a/src/tests/test_progress_tracker.py
+++ b/src/tests/test_progress_tracker.py
@@ -1,0 +1,45 @@
+import pytest
+from pathlib import Path
+from src.utils.progress_tracker import ProgressTracker
+
+@pytest.fixture
+def tracker(tmp_path):
+  log_path = tmp_path / 'progress.log'
+  tracker = ProgressTracker(tmp_path / 'progress.log')
+  return tracker
+
+class TestProgressTracker:
+  PATH_1 = "/path/to/file1.jpg"
+  PATH_2 = "/path/to/file2.jpg"
+
+  def test_record_completed_once(self, tracker, tmp_path):
+    tracker.record_completed(Path(self.PATH_1))
+    progress_list = self.load_progress_list(tmp_path)
+    assert progress_list[0] == self.PATH_1
+    assert len(progress_list) == 1
+
+  def test_record_completed_multiple(self, tracker, tmp_path):
+    tracker.record_completed(Path(self.PATH_1))
+    tracker.record_completed(Path(self.PATH_2))
+    progress_list = self.load_progress_list(tmp_path)
+    assert progress_list[0] == self.PATH_1
+    assert progress_list[1] == self.PATH_2
+    assert len(progress_list) == 2
+
+  def test_reset_log(self, tracker, tmp_path):
+    tracker.record_completed(Path(self.PATH_1))
+    tracker.reset_log()
+    progress_list = self.load_progress_list(tmp_path)
+    assert len(progress_list) == 0
+
+  def test_is_complete(self, tracker):
+    tracker.record_completed(Path(self.PATH_1))
+    assert tracker.is_complete(self.PATH_1)
+
+  def test_is_complete_false(self, tracker):
+    tracker.record_completed(Path(self.PATH_1))
+    assert not tracker.is_complete(self.PATH_2)
+
+  def load_progress_list(self, tmp_path):
+    with open(tmp_path / 'progress.log') as f:
+      return list(line for line in f.read().splitlines())

--- a/src/utils/classifier_config.py
+++ b/src/utils/classifier_config.py
@@ -10,6 +10,7 @@ class ClassifierConfig:
     self.min_dimension = None
     self.output_base_path = Path('.')
     self.src_base_path = None
+    self.progress_log_path = None
     self.force = False
     if path != None:
       self.load_config(path)
@@ -26,4 +27,5 @@ class ClassifierConfig:
       self.min_dimension = data.get('min_dimension', None)
       self.output_base_path = Path(data['output_base_path']) if 'output_base_path' in data else None
       self.src_base_path = Path(data['src_base_path']) if 'src_base_path' in data else None
+      self.progress_log_path = Path(data['progress_log_path']) if 'progress_log_path' in data else None
       self.force = bool(data.get('force', False))

--- a/src/utils/classifier_report.py
+++ b/src/utils/classifier_report.py
@@ -63,7 +63,7 @@ class ReportGenerator:
                             searchPanes: {{viewTotal: true, layout: 'columns-4', initCollapsed: true}},
                             dom: 'Plfrtip',
                             columns: [
-                                {{ title: 'Image', data: 'normalized_path', render: (d,t,r,m) => '<img src="'+d+'" style=height:200px; />'}},
+                                {{ title: 'Image', data: 'normalized_path', render: (d,t,r,m) => '<img src="'+d+'" style=height:200px; loading="lazy" />'}},
                                 {{ title: 'Path', data: 'original_path'}},
                                 {{ title: 'Class', data: 'predicted_class'}},
                                 {{ title: 'Confidence', data: 'predicted_conf'}}

--- a/src/utils/classifier_workflow_service.py
+++ b/src/utils/classifier_workflow_service.py
@@ -18,8 +18,9 @@ class ClassifierWorkflowService:
     self.classifier = ImageClassifier(config)
     self.progress_tracker = ProgressTracker(config.progress_log_path)
     if restart:
-      print(f'Restarting progress tracking')
+      print(f'Restarting progress tracking and reporting')
       self.progress_tracker.reset_log()
+      self.report_path.unlink()
 
   def process(self, paths):
     total = len(paths)

--- a/src/utils/progress_tracker.py
+++ b/src/utils/progress_tracker.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+import json
+
+# Utility for tracking what items have been processed already, to support resumption
+class ProgressTracker:
+  def __init__(self, log_path):
+    self.log_path = log_path
+    self.completed = None
+
+  def reset_log(self):
+    with open(self.log_path, "a") as log_file:
+      log_file.truncate(0)
+
+  def completed_set(self):
+    if self.completed == None:
+      if self.log_path.is_file():
+        with open(self.log_path) as f:
+          self.completed = set(line for line in f.read().splitlines())
+      else:
+        self.completed = set([])
+    return self.completed
+
+  # Check if the given path has been completed in a previous run
+  def is_complete(self, path):
+    return str(path) in self.completed_set()
+
+  # Record a completed path to the log
+  def record_completed(self, path):
+    with open(self.log_path, "a") as log_file:
+      print(str(path), file=log_file)


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-4251

* Add support for resuming a classification workflow, using a progress log at a path defined in the configuration.
    * Adds an option for clearing the progress before starting, so that it will start at the beginning
* Adds a simple ProgressTracker utility for recording progress (in this case paths of completed files), and the ability to look up if an item has previously been processed.