### PR TITLE
[BXC-4035] Creates a ColorBarSegmentationDataset class and masking functions

### DIFF
--- a/src/datasets/color_bar_classifying_dataset.py
+++ b/src/datasets/color_bar_classifying_dataset.py
@@ -1,5 +1,4 @@
 from src.datasets.color_bar_dataset import ColorBarDataset
-from pathlib import Path
 
 # Dataset with single class for labeling images as having a color bar or not
 class ColorBarClassifyingDataset(ColorBarDataset):

--- a/src/datasets/color_bar_dataset.py
+++ b/src/datasets/color_bar_dataset.py
@@ -1,8 +1,6 @@
-import os
 import numpy as np
 import torch
 from pathlib import Path
-from PIL import Image
 from src.utils.resnet_utils import load_for_resnet
 from src.utils.json_utils import from_json
 

--- a/src/datasets/color_bar_dataset.py
+++ b/src/datasets/color_bar_dataset.py
@@ -14,6 +14,7 @@ class ColorBarDataset(torch.utils.data.Dataset):
     self.labels = []
     self.split = split
     self.image_paths = image_paths
+    self.image_dimensions = [] 
     # Load the annotations from label studio
     annotations = from_json(self.config.annotations_path)
     # build a map of image file paths to label info

--- a/src/datasets/color_bar_segmentation_dataset.py
+++ b/src/datasets/color_bar_segmentation_dataset.py
@@ -1,7 +1,7 @@
 import logging
 from numpy import zeros, uint8
 from src.datasets.color_bar_dataset import ColorBarDataset
-from src.utils.resnet_utils import load_for_resnet
+from src.utils.resnet_utils import load_for_resnet, load_mask_for_resnet
 from pathlib import Path
 from PIL import Image, ImageDraw
 
@@ -11,10 +11,10 @@ class ColorBarSegmentationDataset(ColorBarDataset):
     super().__init__(config, image_paths, split)
   
   # Must be overriden from parent class
-  # def __getitem__(self, index):
-    # image_data = load_for_resnet(self.image_paths[index], self.config.max_dimension)
-    # label_mask = None
-    #return image_data, label_mask
+  def __getitem__(self, index):
+    image_data = load_for_resnet(self.image_paths[index], self.config.max_dimension)
+    label_mask = load_mask_for_resnet(self.labels[index], self.config.max_dimension)
+    return image_data, label_mask
 
   # Loads annotation data into self.labels in the same order they paths are listed in image_paths
   def load_labels(self, path_to_labels):
@@ -22,7 +22,7 @@ class ColorBarSegmentationDataset(ColorBarDataset):
    for index, image_path in enumerate(self.image_paths):
      if not image_path:
        continue
-      # Add image dimensions
+    # Add image dimensions
      w, h = None, None
      with Image.open(image_path) as img:
       w, h = img.width, img.height
@@ -37,6 +37,6 @@ class ColorBarSegmentationDataset(ColorBarDataset):
         y = int(label['y']/100.0 * label['original_height'])
         x2 = x + int(width/100.0 * label['original_width']) # bar width
         y2 = y + int(height/100.0 * label['original_height']) # bar height
-        mask[y:y2, x:x2] = 1
+        mask[y:y2, x:x2] = 1 # Mark all pixels in the masked region with ones
      self.labels.append(mask) 
          

--- a/src/datasets/color_bar_segmentation_dataset.py
+++ b/src/datasets/color_bar_segmentation_dataset.py
@@ -1,0 +1,42 @@
+import logging
+from numpy import zeros, uint8
+from src.datasets.color_bar_dataset import ColorBarDataset
+from src.utils.resnet_utils import load_for_resnet
+from pathlib import Path
+from PIL import Image, ImageDraw
+
+# Dataset with single class for labeling images as having a color bar or not
+class ColorBarSegmentationDataset(ColorBarDataset):
+  def __init__(self, config, image_paths, split = 'train'):
+    super().__init__(config, image_paths, split)
+  
+  # Must be overriden from parent class
+  # def __getitem__(self, index):
+    # image_data = load_for_resnet(self.image_paths[index], self.config.max_dimension)
+    # label_mask = None
+    #return image_data, label_mask
+
+  # Loads annotation data into self.labels in the same order they paths are listed in image_paths
+  def load_labels(self, path_to_labels):
+   # The label must be a mask rather than a binary [0,1] class 
+   for index, image_path in enumerate(self.image_paths):
+     if not image_path:
+       continue
+      # Add image dimensions
+     w, h = None, None
+     with Image.open(image_path) as img:
+      w, h = img.width, img.height
+     self.image_dimensions.append((w, h))
+     # Populate label masks
+     image_labels = path_to_labels[str(image_path)]
+     mask = zeros((h, w), dtype=uint8)
+     for label in image_labels:
+       if 'color_bar' in label['rectanglelabels']:
+        x, y, width, height = int(label['x']), int(label['y']), int(label['width']), int(label['height'])
+        x = int(label['x']/100.0 * label['original_width'])
+        y = int(label['y']/100.0 * label['original_height'])
+        x2 = x + int(width/100.0 * label['original_width']) # bar width
+        y2 = y + int(height/100.0 * label['original_height']) # bar height
+        mask[y:y2, x:x2] = 1
+     self.labels.append(mask) 
+         

--- a/src/datasets/color_bar_segmentation_dataset.py
+++ b/src/datasets/color_bar_segmentation_dataset.py
@@ -1,7 +1,7 @@
 from numpy import zeros, uint8
-from torch import max
 from src.datasets.color_bar_dataset import ColorBarDataset
 from src.utils.resnet_utils import load_for_resnet, load_mask_for_resnet
+from torchvision.transforms import ToPILImage
 from PIL import Image
 
 # Dataset with single class for labeling images as having a color bar or not
@@ -16,27 +16,33 @@ class ColorBarSegmentationDataset(ColorBarDataset):
     label_mask = label_mask.clamp(0,1)
     return image_data, label_mask
 
+  # Helper function for displaying tensors representing masks or images
+  def visualize_tensor(self, tensor):
+    transform = ToPILImage()
+    img = transform(tensor)
+    img.show()
+
   # Loads annotation data into self.labels in the same order they paths are listed in image_paths
   def load_labels(self, path_to_labels):
    # The label must be a mask rather than a binary [0,1] class 
-   for index, image_path in enumerate(self.image_paths):
-     if not image_path:
-       continue
-    # Add image dimensions
-     w, h = None, None
-     with Image.open(image_path) as img:
-      w, h = img.width, img.height
-     self.image_dimensions.append((w, h))
-     # Populate label masks
-     image_labels = path_to_labels[str(image_path)]
-     mask = zeros((h, w), dtype=uint8)
-     for label in image_labels:
-       if 'color_bar' in label['rectanglelabels']:
-        width, height = (label['width']), (label['height'])
-        x = int(label['x']/100 * label['original_width'])
-        y = int(label['y']/100 * label['original_height'])
-        x2 = x + int(width/100 * label['original_width']) # bar width
-        y2 = y + int(height/100 * label['original_height']) # bar height
-        mask[y:y2, x:x2] = 1 # Mark all pixels in the masked region with ones
-     self.labels.append(mask) 
+    for index, image_path in enumerate(self.image_paths):
+      if not image_path:
+        continue
+      # Add image dimensions
+      w, h = None, None
+      with Image.open(image_path) as img:
+        w, h = img.width, img.height
+      self.image_dimensions.append((w, h))
+      # Populate label masks
+      image_labels = path_to_labels[str(image_path)]
+      mask = zeros((h, w), dtype=uint8)
+      for label in image_labels:
+        if 'color_bar' in label['rectanglelabels']:
+          width, height = label['width'], label['height']
+          x = int(label['x']/100 * label['original_width'])
+          y = int(label['y']/100 * label['original_height'])
+          x2 = x + int(width/100 * label['original_width']) # bar width
+          y2 = y + int(height/100 * label['original_height']) # bar height
+          mask[y:y2, x:x2] = 1 # Mark all pixels in the masked region with ones
+      self.labels.append(mask) 
          

--- a/src/datasets/color_bar_segmentation_dataset.py
+++ b/src/datasets/color_bar_segmentation_dataset.py
@@ -1,9 +1,9 @@
 import logging
 from numpy import zeros, uint8
+from torch import max
 from src.datasets.color_bar_dataset import ColorBarDataset
 from src.utils.resnet_utils import load_for_resnet, load_mask_for_resnet
-from pathlib import Path
-from PIL import Image, ImageDraw
+from PIL import Image
 
 # Dataset with single class for labeling images as having a color bar or not
 class ColorBarSegmentationDataset(ColorBarDataset):
@@ -14,6 +14,7 @@ class ColorBarSegmentationDataset(ColorBarDataset):
   def __getitem__(self, index):
     image_data = load_for_resnet(self.image_paths[index], self.config.max_dimension)
     label_mask = load_mask_for_resnet(self.labels[index], self.config.max_dimension)
+    label_mask = label_mask.clamp(0,1)
     return image_data, label_mask
 
   # Loads annotation data into self.labels in the same order they paths are listed in image_paths
@@ -32,11 +33,11 @@ class ColorBarSegmentationDataset(ColorBarDataset):
      mask = zeros((h, w), dtype=uint8)
      for label in image_labels:
        if 'color_bar' in label['rectanglelabels']:
-        x, y, width, height = int(label['x']), int(label['y']), int(label['width']), int(label['height'])
-        x = int(label['x']/100.0 * label['original_width'])
-        y = int(label['y']/100.0 * label['original_height'])
-        x2 = x + int(width/100.0 * label['original_width']) # bar width
-        y2 = y + int(height/100.0 * label['original_height']) # bar height
+        width, height = (label['width']), (label['height'])
+        x = int(label['x']/100 * label['original_width'])
+        y = int(label['y']/100 * label['original_height'])
+        x2 = x + int(width/100 * label['original_width']) # bar width
+        y2 = y + int(height/100 * label['original_height']) # bar height
         mask[y:y2, x:x2] = 1 # Mark all pixels in the masked region with ones
      self.labels.append(mask) 
          

--- a/src/datasets/color_bar_segmentation_dataset.py
+++ b/src/datasets/color_bar_segmentation_dataset.py
@@ -1,4 +1,3 @@
-import logging
 from numpy import zeros, uint8
 from torch import max
 from src.datasets.color_bar_dataset import ColorBarDataset

--- a/src/tests/test_color_bar_segmentation_dataset.py
+++ b/src/tests/test_color_bar_segmentation_dataset.py
@@ -39,5 +39,5 @@ class TestColorBarSegmentationDataset:
     assert count_nonzero(mask2[0]) == 0 
     assert count_nonzero(mask2[100]) == 1318
     assert count_nonzero(mask2[1332]) == 0
-    dataset.visualize_tensor(item2) # Demonstrates the tensor visualization method
-    dataset.visualize_tensor(mask2)
+    # dataset.visualize_tensor(item2) # Demonstrates the tensor visualization method
+    # dataset.visualize_tensor(mask2)

--- a/src/tests/test_color_bar_segmentation_dataset.py
+++ b/src/tests/test_color_bar_segmentation_dataset.py
@@ -39,3 +39,5 @@ class TestColorBarSegmentationDataset:
     assert count_nonzero(mask2[0]) == 0 
     assert count_nonzero(mask2[100]) == 1318
     assert count_nonzero(mask2[1332]) == 0
+    dataset.visualize_tensor(item2) # Demonstrates the tensor visualization method
+    dataset.visualize_tensor(mask2)

--- a/src/tests/test_color_bar_segmentation_dataset.py
+++ b/src/tests/test_color_bar_segmentation_dataset.py
@@ -4,6 +4,8 @@ import random
 from src.datasets.color_bar_segmentation_dataset import ColorBarSegmentationDataset
 from src.utils.training_config import TrainingConfig
 from src.utils.json_utils import to_json
+from torch import count_nonzero, all
+import logging
 
 class TestColorBarSegmentationDataset:
   def test_with_simple_data(self, tmp_path):
@@ -23,13 +25,19 @@ class TestColorBarSegmentationDataset:
     dataset = ColorBarSegmentationDataset(config, image_paths)
     assert dataset.__len__() == 13
     assert len(dataset.image_dimensions) == len(dataset)
+    assert dataset.image_dimensions[0] == (1333, 964)
+    item0, mask0 = dataset.__getitem__(0)
+    assert list(item0.shape) == [3, 1333, 1333] 
+    assert count_nonzero(mask0) == 0 # Negative example should have an all-zero mask
     assert len(dataset.labels) == 13
-    item0 = dataset.__getitem__(0)
-    assert list(item0[0].shape) == [3, 1333, 1333]
-    # assert item0[1] == 0
-    # item1 = dataset.__getitem__(1)
-    # assert list(item1[0].shape) == [3, 1333, 1333]
-    # assert item1[1] == 1
-    # assert dataset.__getitem__(2)[1] == 1
-    # assert dataset.__getitem__(3)[1] == 0
-    # assert dataset.__getitem__(4)[1] == 1
+    item1, mask1 = dataset.__getitem__(1) 
+    assert list(item1.shape) == [3, 1333, 1333] # Check dimensions of cropped image
+    assert list(mask1.shape) == [1333, 1333] # Check dimensions of cropped mask
+    assert all((mask1 == 0) | (mask1 == 1)) # Verify mask is binary
+    assert count_nonzero(mask1) == 365242 # 274 * 1333 pixels are marked as color bars
+    item2, mask2 = dataset.__getitem__(6) # Has color bar with margins on all sides after resize
+    assert list(item2.shape) == [3, 1333, 1333]
+    assert count_nonzero(mask2) == 297868 # 1318 * 226 pixels are marked as color bars
+    assert count_nonzero(mask2[0]) == 0 
+    assert count_nonzero(mask2[100]) == 1318
+    assert count_nonzero(mask2[1332]) == 0

--- a/src/tests/test_color_bar_segmentation_dataset.py
+++ b/src/tests/test_color_bar_segmentation_dataset.py
@@ -1,11 +1,9 @@
-import logging
 from pathlib import Path
 import random
 from src.datasets.color_bar_segmentation_dataset import ColorBarSegmentationDataset
 from src.utils.training_config import TrainingConfig
 from src.utils.json_utils import to_json
 from torch import count_nonzero, all
-import logging
 
 class TestColorBarSegmentationDataset:
   def test_with_simple_data(self, tmp_path):

--- a/src/tests/test_color_bar_segmentation_dataset.py
+++ b/src/tests/test_color_bar_segmentation_dataset.py
@@ -1,0 +1,35 @@
+import logging
+from pathlib import Path
+import random
+from src.datasets.color_bar_segmentation_dataset import ColorBarSegmentationDataset
+from src.utils.training_config import TrainingConfig
+from src.utils.json_utils import to_json
+
+class TestColorBarSegmentationDataset:
+  def test_with_simple_data(self, tmp_path):
+    random.seed(10)
+    config_path = tmp_path / 'config.json'
+    to_json({
+      'image_list_path' : 'fixtures/mini_file_list.txt',
+      'annotations_path' : 'fixtures/mini_annotations.json',
+      'base_image_path' : str(Path("fixtures/normalized_images").resolve()),
+      'dataset_class' : 'src.datasets.color_bar_classifying_dataset.ColorBarClassifyingDataset',
+      'max_dimension' : 1333
+    }, config_path)
+    config = TrainingConfig(config_path)
+
+    with open(config.image_list_path) as f:
+      image_paths = [Path(p).resolve() for p in f.read().splitlines()]
+    dataset = ColorBarSegmentationDataset(config, image_paths)
+    assert dataset.__len__() == 13
+    assert len(dataset.image_dimensions) == len(dataset)
+    assert len(dataset.labels) == 13
+    item0 = dataset.__getitem__(0)
+    assert list(item0[0].shape) == [3, 1333, 1333]
+    # assert item0[1] == 0
+    # item1 = dataset.__getitem__(1)
+    # assert list(item1[0].shape) == [3, 1333, 1333]
+    # assert item1[1] == 1
+    # assert dataset.__getitem__(2)[1] == 1
+    # assert dataset.__getitem__(3)[1] == 0
+    # assert dataset.__getitem__(4)[1] == 1

--- a/src/utils/resnet_utils.py
+++ b/src/utils/resnet_utils.py
@@ -1,5 +1,6 @@
 from PIL import Image
-from torchvision import transforms, from_numpy
+from torch import from_numpy
+from torchvision import transforms
 import torchvision.models as models
 import torch.nn as nn
 
@@ -14,12 +15,12 @@ def load_for_resnet(path, max_dimension):
   ])
   return preprocess(input_image)
 
-# Transform mask np.Array based on the requirements of resnet and convert to a tensor
+# Transform binary mask nd.Array for image segmentation, convert to a tensor
 def load_mask_for_resnet(mask_array, max_dimension):
   mask = from_numpy(mask_array).float()
   preprocess = transforms.Compose([
       # Crops masks with identical transformations to images
-      transforms.CenterCrop(max_dimension),
+      transforms.CenterCrop(max_dimension)
   ])
   return preprocess(mask)
 

--- a/src/utils/resnet_utils.py
+++ b/src/utils/resnet_utils.py
@@ -1,5 +1,5 @@
 from PIL import Image
-from torchvision import transforms
+from torchvision import transforms, from_numpy
 import torchvision.models as models
 import torch.nn as nn
 
@@ -13,6 +13,15 @@ def load_for_resnet(path, max_dimension):
       transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
   ])
   return preprocess(input_image)
+
+# Transform mask np.Array based on the requirements of resnet and convert to a tensor
+def load_mask_for_resnet(mask_array, max_dimension):
+  mask = from_numpy(mask_array).float()
+  preprocess = transforms.Compose([
+      # Crops masks with identical transformations to images
+      transforms.CenterCrop(max_dimension),
+  ])
+  return preprocess(mask)
 
 def resnet_foundation_model(device, resnet_depth = 50):
   foundation = None


### PR DESCRIPTION
Creates a ColorBarSegmentationDataset subclass designed for image segmentation rather than classification. Also implements transformation functions to create a binary [0,1] mask representing regions of images with color bars. To be followed by a segmentation_workflow_service.py to train and evaluate a model with the new image, target mappings that computes cross-entropy loss as a weighted pixel-by-pixel difference between predicted color bar regions and ground truth masks.

Rather than return a mage, binary label tuple, the segmentation dataset class returns an image, mask tuple. Masks are initially computed as binary two dimensional arrays of size [H, W] where H, W are the height and width of the original image, then resized using a similar transformation function to the original image to fit into resnet. 

The correctness of masked regions computed has been tested by visual comparison of transformed masks to transformed images (using img.show() on converted tensors) in addition to the unit tests provided.

**Input Image**
![image](https://github.com/UNC-Libraries/ml-repo-preingest-processing/assets/7553742/cfd0036b-6fa5-4084-8365-3f7b84ea0ba0)

**Input Tensor After Normalization and Resizing**
![image](https://github.com/UNC-Libraries/ml-repo-preingest-processing/assets/7553742/e18da108-2b77-4f2c-aca9-362657047b3f)

**Mask Target Tensor After Resizing**
![image](https://github.com/UNC-Libraries/ml-repo-preingest-processing/assets/7553742/c58e20dd-8d29-481a-8026-e430015bb479)

