### PR TITLE
Finalizes ColorBarSegmentationDataset Class

### DIFF
--- a/src/datasets/color_bar_segmentation_dataset.py
+++ b/src/datasets/color_bar_segmentation_dataset.py
@@ -1,10 +1,15 @@
-from numpy import zeros, uint8
+from numpy import zeros
 from src.datasets.color_bar_dataset import ColorBarDataset
 from src.utils.resnet_utils import load_for_resnet, load_mask_for_resnet
-from torchvision.transforms import ToPILImage
+from torchvision.transforms.functional import to_pil_image
+from torchvision.utils import draw_segmentation_masks
+
 from PIL import Image
 
-# Dataset with single class for labeling images as having a color bar or not
+# Dataset class for segmenting images into color bar and subject (negative) regions
+# Returns image, target tuples as two tensors:
+# A normalized image of (3, h, w) and a mask of (1, h, w)
+# Where h and w are image dimensions after being resized for resnet
 class ColorBarSegmentationDataset(ColorBarDataset):
   def __init__(self, config, image_paths, split = 'train'):
     super().__init__(config, image_paths, split)
@@ -13,14 +18,15 @@ class ColorBarSegmentationDataset(ColorBarDataset):
   def __getitem__(self, index):
     image_data = load_for_resnet(self.image_paths[index], self.config.max_dimension)
     label_mask = load_mask_for_resnet(self.labels[index], self.config.max_dimension)
-    label_mask = label_mask.clamp(0,1)
+    label_mask = label_mask.bool()
     return image_data, label_mask
 
-  # Helper function for displaying tensors representing masks or images
-  def visualize_tensor(self, tensor):
-    transform = ToPILImage()
-    img = transform(tensor)
-    img.show()
+  # Helper function for displaying masks imposed on transformed image tensors
+  def visualize_tensor(self, img, mask):
+    img = (img.clamp(0, 1) * 255).byte() # Scales back to uint8 for compatibility
+    masking = draw_segmentation_masks(img, mask, alpha=0.7, colors="blue")
+    masking = to_pil_image(masking)
+    masking.show()
 
   # Loads annotation data into self.labels in the same order they paths are listed in image_paths
   def load_labels(self, path_to_labels):
@@ -33,9 +39,8 @@ class ColorBarSegmentationDataset(ColorBarDataset):
       with Image.open(image_path) as img:
         w, h = img.width, img.height
       self.image_dimensions.append((w, h))
-      # Populate label masks
       image_labels = path_to_labels[str(image_path)]
-      mask = zeros((h, w), dtype=uint8)
+      mask = zeros((h, w), dtype=bool)
       for label in image_labels:
         if 'color_bar' in label['rectanglelabels']:
           width, height = label['width'], label['height']
@@ -45,4 +50,3 @@ class ColorBarSegmentationDataset(ColorBarDataset):
           y2 = y + int(height/100 * label['original_height']) # bar height
           mask[y:y2, x:x2] = 1 # Mark all pixels in the masked region with ones
       self.labels.append(mask) 
-         

--- a/src/tests/test_color_bar_segmentation_dataset.py
+++ b/src/tests/test_color_bar_segmentation_dataset.py
@@ -13,7 +13,7 @@ class TestColorBarSegmentationDataset:
       'image_list_path' : 'fixtures/mini_file_list.txt',
       'annotations_path' : 'fixtures/mini_annotations.json',
       'base_image_path' : str(Path("fixtures/normalized_images").resolve()),
-      'dataset_class' : 'src.datasets.color_bar_classifying_dataset.ColorBarClassifyingDataset',
+      'dataset_class' : 'src.datasets.color_bar_segmentation_dataset.ColorBarSegmentationDataset',
       'max_dimension' : 1333
     }, config_path)
     config = TrainingConfig(config_path)
@@ -39,5 +39,5 @@ class TestColorBarSegmentationDataset:
     assert count_nonzero(mask2[0]) == 0 
     assert count_nonzero(mask2[100]) == 1318
     assert count_nonzero(mask2[1332]) == 0
-    # dataset.visualize_tensor(item2) # Demonstrates the tensor visualization method
-    # dataset.visualize_tensor(mask2)
+    dataset.visualize_tensor(item2, mask2)
+    dataset.visualize_tensor(item0, mask0)

--- a/src/utils/resnet_utils.py
+++ b/src/utils/resnet_utils.py
@@ -17,7 +17,7 @@ def load_for_resnet(path, max_dimension):
 
 # Transform binary mask nd.Array for image segmentation, convert to a tensor
 def load_mask_for_resnet(mask_array, max_dimension):
-  mask = from_numpy(mask_array).float()
+  mask = from_numpy(mask_array)
   preprocess = transforms.Compose([
       # Crops masks with identical transformations to images
       transforms.CenterCrop(max_dimension)


### PR DESCRIPTION
Replaces a custom masking preview function that would preview images and mask tensors individually with the [official draw_segmentation_masks](https://pytorch.org/vision/stable/generated/torchvision.utils.draw_segmentation_masks.html) function from PyTorch that combines masks and images into a single preview image. Makes the generated mask tensor a boolean rather than a float for compatibility. Tweaks to comments.