### PR TITLE
Client side review functionality

### DIFF
--- a/src/utils/classifier_report.py
+++ b/src/utils/classifier_report.py
@@ -311,7 +311,7 @@ class ReportGenerator:
                             
                             let encodedUri = encodeURI(csvContent);
                             $("#reviewLink").attr("href", encodedUri)
-                            $("#reviewLink").click();
+                            $("#reviewLink").trigger("click");
                             window.open(encodedUri);
                             
                           })

--- a/src/utils/classifier_report.py
+++ b/src/utils/classifier_report.py
@@ -301,7 +301,7 @@ class ReportGenerator:
                         # exports reviewed items as CSV
                         a('''
                           $("#reviewButton").click( () => {
-                            let reviewData = JSON.parse(localStorage.get("reviewItems"));
+                            let reviewData = JSON.parse(localStorage.getItem("reviewItems"));
                             reviewData = reviewData.map(e => {
                                 e['corrected_class'] = Number(e['predicted_class'] == e['review'])
                             })

--- a/src/utils/classifier_report.py
+++ b/src/utils/classifier_report.py
@@ -268,8 +268,9 @@ class ReportGenerator:
                         # function to update review export button
                         a('''
                           let updateReviewButton = () => {
-                            $("#reviewButton").text(`Export ${JSON.parse(localStorage.getItem("reviewItems")).length} reviewed items`)
-                            if (localStorage.length == 0) {
+                            let len = JSON.parse(localStorage.getItem("reviewItems")).length
+                            $("#reviewButton").text(`Export ${len} reviewed items`)
+                            if (len == 0) {
                                     $("#reviewButton").prop("disabled",true);
                             } else {
                                 $("#reviewButton").prop("disabled",false);
@@ -281,9 +282,8 @@ class ReportGenerator:
                         a('''
                         if (localStorage.length == 0) {
                             localStorage.setItem("reviewItems", "[]");  
-                        } else {
-                            updateReviewButton();
-                        }
+                            }
+                        updateReviewButton();
                         ''')
                         # saves input data to localstorage when checked and updates review button
                         a('''

--- a/src/utils/classifier_report.py
+++ b/src/utils/classifier_report.py
@@ -303,16 +303,17 @@ class ReportGenerator:
                           $("#reviewButton").click( () => {
                             let reviewData = JSON.parse(localStorage.getItem("reviewItems"));
                             reviewData = reviewData.map(e => {
+                                e = JSON.parse(e);
                                 e['corrected_class'] = Number(e['predicted_class'] == e['review'])
+                                return e
                             })
                             let csvContent = "data:text/csv;charset=utf-8,"
                             csvContent += "path,predicted_class,corrected_class\\n"
-                            csvContent += reviewData.map(e => `${e['path'],e['predicted_class'],e['corrected_class']}`).join("\\n")
-                            
+                            csvContent += reviewData.map(e => `${e["path"]}, ${e["predicted_class"]}, ${e["corrected_class"]}`).join("\\n")
+                            console.log(csvContent);
                             let encodedUri = encodeURI(csvContent);
                             $("#reviewLink").attr("href", encodedUri)
                             $("#reviewLink").trigger("click");
-                            window.open(encodedUri);
                             
                           })
                           ''')


### PR DESCRIPTION
Pull request for [Client side review ticket](https://unclibrary.atlassian.net/browse/BXC-4339)

New Features:
- Column labeled "Review" with correct/incorrect buttons
- Button to download CSV with paths, predicted_class, and correct_class columns based on user reviews
- Button to clear selection when there is one or more item reviewed
- Items that have been reviewed are saved to local storage until cleared
- added Bootstrap 5 CDN for button styling and icons


Comments:
The overall aesthetics of the page isn't the best right now, but all the functionality should be there. I will work to make it look nicer, but I thought I should go ahead and open the pull request. 