### PR TITLE
BXC-4490 - Script for cropping images

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,20 @@ Example command:
 python classify.py -c /path/to/color_bars/ml-repo-its-config/configs/classify_locos_test.json /path/to/rbc/11500_popayan/11500_0006/ /path/to/color_bars/shared/reports/results.csv
 ```
 
+## Generating a Report
+`create_report.py` creates HTML report from CSV output from the classifier. It requires a path to the csv prefixed with `-f`.  <br> **Optional arguments**:
+* `-s` followed by the output path of the report HTML file
+* `-n` with the HTTP url to replace the normalized image path
+* `-x` with the substring to indicate the area up to which the images' normalized path will be replaced by the provided HTTP url
+<br>**Optional Flags**:
+* `-A`  Create an aggregate report that allows you to toggle between the item-level and aggregate tables
+* `-O`  Open report in browser once it has been generated
+
+```
+python create_report.py -f /path/to/file.csv -s path/to/save/report.html -n https://example.com -x /shared/ -O
+```
+
+
 # Segmentation Model
 ## Model training
 
@@ -75,6 +89,27 @@ To use a pretrained model over a set of images (directories or individual files)
 python segmenter_predict.py -c /path/to/color_bars/ml-repo-its-config/configs/segmenter_locos_test.json /path/to/rbc/11500_popayan/11500_0006/ /path/to/color_bars/shared/reports/seg_results.csv
 ```
 
+## Generating segmentation report
+Produces an HTML report from a segmenter_predict CSV output. The `-d` parameter is the path to a new directory where the report will be written. If it already exists, the script will not do anything. The `-n` parameter is optional and is used to make paths to normalized images relative rather than absolute.
+
+```
+python create_seg_report.py -f /path/to/color_bars/shared/reports/seg_results.csv -d /path/to/output/reports/new_report_dir -n /path/to/make/original/paths/relative/to
+```
+
+## Cropping images
+Produces cropped versions of original image files listed in a CSV file produced by segmenter_predict. The first parameter is the path to the CSV, the second is the path where the cropped images will be written to. 
+
+The cropped images will be written at paths based on the their original path. By default, if the original path was `/path/to/originals/a/b/image.tif`, and the output path was `/path/to/output/cropped/`, then the cropped version would be written to `/path/to/output/cropped/path/to/originals/a/b/image.jpg`. 
+
+The `-b` option can be used to make paths shorter by making them relative to some base path, so if a `-b` option is provided as `/path/to/originals`, then the cropped version would be written to `/path/to/output/cropped/a/b/image.jpg`.
+
+The `-e` option can be provided in order to tell the script to skip over certain images. It takes a path which should point to a CSV file, where the first column is the original path to the file to skip.
+
+```
+python crop.py /path/to/color_bars/shared/reports/seg_results.csv /path/to/output/cropped/ -b /path/to/make/original/paths/relative/to
+```
+
+
 # Viewing training metrics
 Training details are logged using tensorboard. They can be viewed by running:
 ```
@@ -82,18 +117,6 @@ tensorboard --logdir logs/lightning_logs/version_1
 ```
 And then going to http://localhost:6006/
 
-# Generating a Report
-`create_report.py` creates HTML report from CSV output from the classifier. It requires a path to the csv prefixed with `-f`.  <br> **Optional arguments**:
-* `-s` followed by the output path of the report HTML file
-* `-n` with the HTTP url to replace the normalized image path
-* `-x` with the substring to indicate the area up to which the images' normalized path will be replaced by the provided HTTP url
-<br>**Optional Flags**:
-* `-A`  Create an aggregate report that allows you to toggle between the item-level and aggregate tables
-* `-O`  Open report in browser once it has been generated
-
-```
-python create_report.py -f /path/to/file.csv -s path/to/save/report.html -n https://example.com -x /shared/ -O
-```
 
 # Running tests
 To run the tests in your local environment (or python3 depending on the environment):

--- a/crop.py
+++ b/crop.py
@@ -1,0 +1,32 @@
+from src.utils.cropping_workflow_service import CroppingWorkflowService
+import argparse
+from pathlib import Path
+from datetime import datetime
+from src.utils.common_utils import log
+
+parser = argparse.ArgumentParser(description='Using a prediction CSV from segmenter_predict.py, crop original images and save them to an output directory')
+parser.add_argument('csv_path', type=Path,
+                    help='Path to the prediction CSV file')
+parser.add_argument('output_path', type=Path,
+                    help='Base path where the cropped images will be written to.')
+parser.add_argument('-e', '--exclusions', type=Path,
+                    help='If provided, CSV file will be loaded and any file paths in the first column will be skipped during cropping')
+parser.add_argument('-b', '--originals-base', type=Path,
+                    help='Path with original file paths will be relativized against when determining the output path they will be written to'),
+
+args = parser.parse_args()
+
+log(f'Cropping images from CSV: {args.csv_path}')
+log(f'Writing cropped images to: {args.output_path}')
+
+originals_base = Path("/") if args.originals_base == None else args.originals_base
+
+service = CroppingWorkflowService(args.csv_path, args.output_path, exclusions_path = args.exclusions, originals_base_path = originals_base)
+
+cropped_paths = service.process()
+cropped_report = args.output_path / f"cropped{datetime.now().strftime('%Y%m%d%H%M%S')}.txt"
+with open(cropped_report, 'w') as file:
+  for cropped in cropped_paths:
+    file.write(f'{str(cropped)}\n')
+
+log(f'Wrote list of cropped files to {cropped_report.resolve()}')

--- a/fixtures/seg_report.csv
+++ b/fixtures/seg_report.csv
@@ -1,15 +1,15 @@
 original_path,normalized_path,predicted_class,predicted_conf,bounding_box
-fixtures/normalized_images/gilmer/00276_op0217_0001_e.jpg,fixtures/normalized_images/gilmer/00276_op0217_0001_e.jpg,0,0.0000,
-fixtures/normalized_images/gilmer/00276_op0204_0001_tiny.jpg,fixtures/normalized_images/gilmer/00276_op0204_0001_tiny.jpg,0,0.0000,
-fixtures/normalized_images/gilmer/00276_op0204_0001.jpg,fixtures/normalized_images/gilmer/00276_op0204_0001.jpg,1,0.9990,"[0.0, 0.0, 1.0, 0.1709]"
-fixtures/normalized_images/gilmer/00276_op0226a_0001.jpg,fixtures/normalized_images/gilmer/00276_op0226a_0001.jpg,1,0.9996,"[0.0, 0.0, 0.159, 0.7494]"
-fixtures/normalized_images/ncc/P0004_0483_0001_verso.jpg,fixtures/normalized_images/ncc/P0004_0483_0001_verso.jpg,1,0.9905,"[0.0, 0.7941, 1.0, 1.0]"
-fixtures/normalized_images/ncc/P0004_0483_17486.jpg,fixtures/normalized_images/ncc/P0004_0483_17486.jpg,1,0.9965,"[0.0, 0.8689, 1.0, 1.0]"
-fixtures/normalized_images/ncc/G3902-F3-1981_U5_front.jpg,fixtures/normalized_images/ncc/G3902-F3-1981_U5_front.jpg,0,0.0600,
-fixtures/normalized_images/ncc/Cm912_1945u1_sheet1.jpg,fixtures/normalized_images/ncc/Cm912_1945u1_sheet1.jpg,0,0.1621,
-fixtures/normalized_images/ncc/fcpl_005.jpg,fixtures/normalized_images/ncc/fcpl_005.jpg,0,0.0000,
-fixtures/normalized_images/ncc/Cm912m_U58b9.jpg,fixtures/normalized_images/ncc/Cm912m_U58b9.jpg,1,0.9609,"[0.0, 0.0, 1.0, 0.2136]"
-fixtures/normalized_images/sfc/20367_pf0406_01_0002.jpg,fixtures/normalized_images/sfc/20367_pf0406_01_0002.jpg,0,0.0775,
-fixtures/normalized_images/sfc/20009_pf0263_0004.jpg,fixtures/normalized_images/sfc/20009_pf0263_0004.jpg,0,0.0000,
-fixtures/normalized_images/rbc/11029-z_pa0001_0017.jpg,fixtures/normalized_images/rbc/11029-z_pa0001_0017.jpg,1,0.9996,"[0.0, 0.0, 0.1365, 1.0]"
-fixtures/normalized_images/rbc/11029-z_pa0001_0034.jpg,fixtures/normalized_images/rbc/11029-z_pa0001_0034.jpg,1,0.9995,"[0.8634, 0.0, 1.0, 1.0]"
+fixtures/normalized_images/gilmer/00276_op0217_0001_e.jpg,fixtures/normalized_images/gilmer/00276_op0217_0001_e.jpg,0,0.0000,,
+fixtures/normalized_images/gilmer/00276_op0204_0001_tiny.jpg,fixtures/normalized_images/gilmer/00276_op0204_0001_tiny.jpg,0,0.0000,,
+fixtures/normalized_images/gilmer/00276_op0204_0001.jpg,fixtures/normalized_images/gilmer/00276_op0204_0001.jpg,1,0.9990,"[0.0, 0.0, 1.0, 0.1709]",
+fixtures/normalized_images/gilmer/00276_op0226a_0001.jpg,fixtures/normalized_images/gilmer/00276_op0226a_0001.jpg,1,0.9996,"[0.0, 0.0, 0.159, 0.7494]","[0.0, 0.0, 0.159, 1.0]"
+fixtures/normalized_images/ncc/P0004_0483_0001_verso.jpg,fixtures/normalized_images/ncc/P0004_0483_0001_verso.jpg,1,0.9905,"[0.0, 0.7941, 1.0, 1.0]",
+fixtures/normalized_images/ncc/P0004_0483_17486.jpg,fixtures/normalized_images/ncc/P0004_0483_17486.jpg,1,0.9965,"[0.0, 0.8689, 1.0, 1.0]",
+fixtures/normalized_images/ncc/G3902-F3-1981_U5_front.jpg,fixtures/normalized_images/ncc/G3902-F3-1981_U5_front.jpg,0,0.0600,,
+fixtures/normalized_images/ncc/Cm912_1945u1_sheet1.jpg,fixtures/normalized_images/ncc/Cm912_1945u1_sheet1.jpg,0,0.1621,,
+fixtures/normalized_images/ncc/fcpl_005.jpg,fixtures/normalized_images/ncc/fcpl_005.jpg,0,0.0000,,
+fixtures/normalized_images/ncc/Cm912m_U58b9.jpg,fixtures/normalized_images/ncc/Cm912m_U58b9.jpg,1,0.9609,"[0.0, 0.0, 1.0, 0.2136]",
+fixtures/normalized_images/sfc/20367_pf0406_01_0002.jpg,fixtures/normalized_images/sfc/20367_pf0406_01_0002.jpg,0,0.0775,,
+fixtures/normalized_images/sfc/20009_pf0263_0004.jpg,fixtures/normalized_images/sfc/20009_pf0263_0004.jpg,0,0.0000,,
+fixtures/normalized_images/rbc/11029-z_pa0001_0017.jpg,fixtures/normalized_images/rbc/11029-z_pa0001_0017.jpg,1,0.9996,"[0.0, 0.0, 0.1365, 1.0]",
+fixtures/normalized_images/rbc/11029-z_pa0001_0034.jpg,fixtures/normalized_images/rbc/11029-z_pa0001_0034.jpg,1,0.9995,"[0.8634, 0.0, 1.0, 1.0]",

--- a/src/tests/test_bounding_box_utils.py
+++ b/src/tests/test_bounding_box_utils.py
@@ -2,7 +2,7 @@ import pytest
 import tempfile
 import os
 from PIL import Image
-from src.utils.bounding_box_utils import draw_bounding_boxes, draw_result_bounding_boxes, extend_bounding_box_to_edges, InvalidBoundingBoxException
+from src.utils.bounding_box_utils import draw_bounding_boxes, draw_result_bounding_boxes, is_problematic_box, extend_bounding_box_to_edges, InvalidBoundingBoxException
 
 @pytest.fixture
 def test_image(tmp_path):
@@ -39,6 +39,22 @@ class TestBoundingBoxUtils:
     # Check if the output image has the expected size
     with Image.open(output_img_path) as img:
       assert img.size == (120, 120)
+
+  def test_is_problematic_box_one_edge(self):
+    coords = [0.0, 0.10288684844970702, 0.0860845947265625, 0.88]
+    assert is_problematic_box(coords)
+
+  def test_is_problematic_box_two_edges(self):
+    coords = [0.0, 0.0, 0.0860845947265625, 0.88]
+    assert is_problematic_box(coords)
+
+  def test_is_problematic_box_three_edges(self):
+    coords = [0.0, 0.0, 0.0860845947265625, 1.0]
+    assert not is_problematic_box(coords)
+
+  def test_is_problematic_box_none(self):
+    coords = None
+    assert not is_problematic_box(coords)
 
   def test_extend_bounding_box_to_edges_one_edge_left(self):
     coords = [0.0, 0.10288684844970702, 0.0860845947265625, 0.88]

--- a/src/tests/test_bounding_box_utils.py
+++ b/src/tests/test_bounding_box_utils.py
@@ -2,7 +2,7 @@ import pytest
 import tempfile
 import os
 from PIL import Image
-from src.utils.bounding_box_utils import draw_bounding_boxes, draw_result_bounding_boxes
+from src.utils.bounding_box_utils import draw_bounding_boxes, draw_result_bounding_boxes, extend_bounding_box_to_edges, InvalidBoundingBoxException
 
 @pytest.fixture
 def test_image(tmp_path):
@@ -39,3 +39,53 @@ class TestBoundingBoxUtils:
     # Check if the output image has the expected size
     with Image.open(output_img_path) as img:
       assert img.size == (120, 120)
+
+  def test_extend_bounding_box_to_edges_one_edge_left(self):
+    coords = [0.0, 0.10288684844970702, 0.0860845947265625, 0.88]
+    result = extend_bounding_box_to_edges(coords)
+    assert [0.0, 0.0, 0.0860845947265625, 1.0] == result
+
+  def test_extend_bounding_box_to_edges_one_edge_top(self):
+    coords = [0.21832839965820314, 0.0, 0.75, 0.05075512886047363]
+    result = extend_bounding_box_to_edges(coords)
+    assert [0.0, 0.0, 1.0, 0.05075512886047363] == result
+
+  def test_extend_bounding_box_to_edges_one_edge_bottom(self):
+    coords = [0.2, 0.9267693074544271, 0.913, 1.0]
+    result = extend_bounding_box_to_edges(coords)
+    assert [0.0, 0.9267693074544271, 1.0, 1.0] == result
+
+  def test_extend_bounding_box_to_edges_one_edge_right(self):
+    coords = [0.8969069417317709, 0.2, 1.0, 0.888]
+    result = extend_bounding_box_to_edges(coords)
+    assert [0.8969069417317709, 0.0, 1.0, 1.0] == result
+
+  def test_extend_bounding_box_to_edges_top_left_edge_corner(self):
+    coords = [0.0, 0.0, 0.10293843587239583, 0.9715890502929687]
+    result = extend_bounding_box_to_edges(coords)
+    assert [0.0, 0.0, 0.10293843587239583, 1.0] == result
+
+  def test_extend_bounding_box_to_edges_bottom_left_edge_corner(self):
+    coords = [0.0, 0.10288684844970702, 0.0860845947265625, 1.0]
+    result = extend_bounding_box_to_edges(coords)
+    assert [0.0, 0.0, 0.0860845947265625, 1.0] == result
+
+  def test_extend_bounding_box_to_edges_top_edge_right_corner(self):
+    coords = [0.21832839965820314, 0.0, 1.0, 0.05075512886047363]
+    result = extend_bounding_box_to_edges(coords)
+    assert [0.0, 0.0, 1.0, 0.05075512886047363] == result
+
+  def test_extend_bounding_box_to_edges_bottom_edge_right_corner(self):
+    coords = [0.8969069417317709, 0.3, 1.0, 1.0]
+    result = extend_bounding_box_to_edges(coords)
+    assert [0.8969069417317709, 0.0, 1.0, 1.0] == result
+
+  def test_extend_bounding_box_to_edges_box_too_big(self):
+    coords = [0.0, 0.47508056640625, 0.9, 1.0]
+    with pytest.raises(InvalidBoundingBoxException) as e_info:
+      result = extend_bounding_box_to_edges(coords)
+
+  def test_extend_bounding_box_to_edges_same_dimensions(self):
+    coords = [0.0, 0.0, 0.21832839965820314, 0.21832839965820314]
+    with pytest.raises(InvalidBoundingBoxException) as e_info:
+      result = extend_bounding_box_to_edges(coords)

--- a/src/tests/test_cropping_workflow_service.py
+++ b/src/tests/test_cropping_workflow_service.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+from src.utils.cropping_workflow_service import CroppingWorkflowService
+
+class TestCroppingWorkflowService:
+  def test_process_defaults(self, tmp_path):
+    csv_path = Path("fixtures/seg_report.csv")
+    output_path = tmp_path / "cropped"
+    service = CroppingWorkflowService(csv_path, output_path)
+
+    cropped_paths = service.process()
+
+    assert 7 == len(cropped_paths)
+    assert all(path.exists() for path in cropped_paths)
+    # Cropped path contains the full path from the root of the file system, made relative to the output directory
+    expected_path1 = output_path / str(Path("fixtures/normalized_images/gilmer/00276_op0204_0001.jpg").resolve())[1:]
+    assert expected_path1 in cropped_paths
+    expected_path2 = output_path / str(Path("fixtures/normalized_images/gilmer/00276_op0226a_0001.jpg").resolve())[1:]
+    assert expected_path2 in cropped_paths
+
+  def test_process_original_relative_path(self, tmp_path):
+    csv_path = Path("fixtures/seg_report.csv")
+    output_path = tmp_path / "cropped"
+    service = CroppingWorkflowService(csv_path, output_path, originals_base_path = Path('fixtures/normalized_images'))
+
+    cropped_paths = service.process()
+
+    assert 7 == len(cropped_paths)
+    assert all(path.exists() for path in cropped_paths)
+    # Cropped path is shortened since it was made relative to fixtures/normalized_images
+    expected_path1 = output_path / "gilmer/00276_op0204_0001.jpg"
+    assert expected_path1 in cropped_paths
+    expected_path2 = output_path / "gilmer/00276_op0226a_0001.jpg"
+    assert expected_path2 in cropped_paths
+
+  def test_process_with_exclusions(self, tmp_path):
+    csv_path = Path("fixtures/seg_report.csv")
+    output_path = tmp_path / "cropped"
+    exclusions_path = tmp_path / "exclude.csv"
+    with open(exclusions_path, 'w') as file:
+      file.write('path,predicted_class,corrected_class\n')
+      # Excluding path which would normally be cropped
+      file.write(f'{Path("fixtures/normalized_images/gilmer/00276_op0204_0001.jpg").resolve()},1,0\n')
+      # Excluding path that would normally not be cropped
+      file.write(f'{Path("fixtures/normalized_images/ncc/Cm912_1945u1_sheet1.jpg").resolve()},1,0\n')
+    service = CroppingWorkflowService(csv_path, output_path, originals_base_path = Path('fixtures/normalized_images'), exclusions_path = exclusions_path)
+
+    cropped_paths = service.process()
+
+    assert 6 == len(cropped_paths)
+    assert all(path.exists() for path in cropped_paths)
+    # Path was excluded path, so it should not have been cropped
+    expected_path1 = output_path / "gilmer/00276_op0204_0001.jpg"
+    assert expected_path1 not in cropped_paths
+    assert not expected_path1.exists()
+    expected_path2 = output_path / "gilmer/00276_op0226a_0001.jpg"
+    assert expected_path2 in cropped_paths

--- a/src/utils/bounding_box_utils.py
+++ b/src/utils/bounding_box_utils.py
@@ -3,7 +3,7 @@ import itertools
 from pathlib import Path
 from src.utils.segmentation_utils import pixels_to_norms, norms_to_pixels
 
-_all__ = ["_draw_bounding_boxes", "_draw_result_bounding_boxes"]
+_all__ = ["_draw_bounding_boxes", "_draw_result_bounding_boxes", "_is_problematic_box", "_number_sides_at_image_edge", "_get_box_coords", "_extend_bounding_box_to_edges"]
 
 def draw_bounding_boxes(img_path, output_path, resize_dims, boxes, retain_ratio = False):
   """
@@ -41,3 +41,61 @@ def draw_result_bounding_boxes(img_paths, base_output_path, resize_dims, target_
   for entry in zip(img_paths, target_boxes, predicted_boxes):
     img_path = Path(entry[0])
     draw_bounding_boxes(img_path, base_output_path / img_path.name, resize_dims, [entry[1], entry[2]])
+
+# Box is problematic if 3 of its sides don't touch the edges of the image
+def is_problematic_box(boxes):
+  if len(boxes) == 0:
+    return False
+  count = number_sides_at_image_edge(boxes)
+  return count != 3
+
+def number_sides_at_image_edge(boxes):
+  count = 0
+  count += boxes[0][0] == 0
+  count += boxes[0][1] == 0
+  count += boxes[0][2] == 1
+  count += boxes[0][3] == 1
+  return count
+
+# Load the coordinates of a bounding box from a CSV row
+def get_box_coords(row):
+  if row[4]:
+    box_coords = json.loads(row[4])
+    return [box_coords]
+  return []
+
+# Used to extend a bounding box that is only touching 1 or 2 image edges, so that it touches 3
+# edges so that it is usable for cropping
+def extend_bounding_box_to_edges(box_coords):
+  coords = box_coords.copy()
+  horizontal_length = coords[2] - coords[0]
+  vertical_length = coords[3] - coords[1]
+  # don't extend if it'll produce a bounding box greater than or equal to half the image
+  if vertical_length >= 0.5 and horizontal_length >= 0.5:
+    raise InvalidBoundingBoxException("Cannot extend bounding box to image edges, total size of bounding box is too large")
+  if vertical_length == horizontal_length:
+    raise InvalidBoundingBoxException("Cannot extend bounding box to image edges, sides are equal length")
+  left_edge = coords[0] == 0
+  right_edge = coords[2] == 1
+  top_edge = coords[1] == 0
+  bottom_edge = coords[3] == 1
+  if (left_edge or right_edge) and (bottom_edge or top_edge):
+    # bounding box touches two edges, so extend longest edge
+    if vertical_length > horizontal_length:
+      coords[1] = 0.0
+      coords[3] = 1.0
+    else:
+      coords[0] = 0.0
+      coords[2] = 1.0
+  else:
+    # Only one side on edge, so extend the two sides perpendicular to that side to the edges
+    if left_edge or right_edge:
+      coords[1] = 0.0
+      coords[3] = 1.0
+    else:
+      coords[0] = 0.0
+      coords[2] = 1.0
+  return coords
+
+class InvalidBoundingBoxException(Exception):
+    pass

--- a/src/utils/bounding_box_utils.py
+++ b/src/utils/bounding_box_utils.py
@@ -1,5 +1,6 @@
 from PIL import Image, ImageDraw
 import itertools
+import json
 from pathlib import Path
 from src.utils.segmentation_utils import pixels_to_norms, norms_to_pixels
 
@@ -43,26 +44,26 @@ def draw_result_bounding_boxes(img_paths, base_output_path, resize_dims, target_
     draw_bounding_boxes(img_path, base_output_path / img_path.name, resize_dims, [entry[1], entry[2]])
 
 # Box is problematic if 3 of its sides don't touch the edges of the image
-def is_problematic_box(boxes):
-  if len(boxes) == 0:
+def is_problematic_box(coords):
+  if coords == None:
     return False
-  count = number_sides_at_image_edge(boxes)
+  count = number_sides_at_image_edge(coords)
   return count != 3
 
-def number_sides_at_image_edge(boxes):
+def number_sides_at_image_edge(coords):
   count = 0
-  count += boxes[0][0] == 0
-  count += boxes[0][1] == 0
-  count += boxes[0][2] == 1
-  count += boxes[0][3] == 1
+  count += coords[0] == 0
+  count += coords[1] == 0
+  count += coords[2] == 1
+  count += coords[3] == 1
   return count
 
 # Load the coordinates of a bounding box from a CSV row
-def get_box_coords(row):
-  if row[4]:
-    box_coords = json.loads(row[4])
-    return [box_coords]
-  return []
+def get_box_coords(row, index = 4):
+  if row[index]:
+    box_coords = json.loads(row[index])
+    return box_coords
+  return None
 
 # Used to extend a bounding box that is only touching 1 or 2 image edges, so that it touches 3
 # edges so that it is usable for cropping

--- a/src/utils/cropping_workflow_service.py
+++ b/src/utils/cropping_workflow_service.py
@@ -31,6 +31,7 @@ class CroppingWorkflowService:
       for row in csv_reader:
         original_path = Path(row[0]).resolve()
         if self.is_excluded(original_path) or not self.has_color_bar(row):
+          log(f'Skipping {original_path}')
           continue
         box_coords = get_box_coords(row)
         if is_problematic_box(box_coords):
@@ -80,4 +81,5 @@ class CroppingWorkflowService:
 
   def cropped_image_output_path(self, img_path):
     relative_path = img_path.relative_to(self.originals_base_path)
+    relative_path = relative_path.parent / (relative_path.stem + ".jpg")
     return self.output_path / relative_path

--- a/src/utils/cropping_workflow_service.py
+++ b/src/utils/cropping_workflow_service.py
@@ -1,0 +1,83 @@
+import csv
+import os
+import traceback
+from pathlib import Path
+from src.utils.image_segmenter import ImageSegmenter
+from src.utils.segmentation_utils import round_box_to_edge, pixels_to_norms, norms_to_pixels, background_box
+from src.utils.bounding_box_utils import is_problematic_box, get_box_coords, number_sides_at_image_edge
+import torch
+from PIL import Image
+from src.utils.common_utils import log
+
+# Service which accepts a prediction CSV, and generates cropped versions of listed original
+# images if they were predicted to contain color bars.
+# Cropped images are written to the provided output path.
+class CroppingWorkflowService:
+  def __init__(self, csv_path, output_path, exclusions_path = None, originals_base_path = Path("/")):
+    self.csv_path = csv_path
+    self.output_path = output_path
+    self.exclusions_path = exclusions_path
+    self.originals_base_path = originals_base_path.resolve()
+    self.cropped_paths = []
+  
+  def process(self):
+    # Load exclusion paths
+    self.load_exclusions()
+    # Load segmentation csv report
+    with open(self.csv_path, newline='') as csvfile:
+      csv_reader = csv.reader(csvfile)
+      # Skip the header
+      next(csv_reader, None)
+      for row in csv_reader:
+        original_path = Path(row[0]).resolve()
+        if self.is_excluded(original_path) or not self.has_color_bar(row):
+          continue
+        box_coords = get_box_coords(row)
+        if is_problematic_box(box_coords):
+          extended_box = get_box_coords(row, index = 5)
+          if extended_box == None:
+            log(f'ERROR: File {original_path} has problematic bounding box that could not be extrapolated, skipping')
+            continue
+          else:
+            log(f'WARN: File {original_path} has bounding box that has been extrapolated to image edges')
+            box_coords = extended_box
+        log(f'Cropping {original_path}')
+        cropped_path = self.crop_image(original_path, box_coords)
+        self.cropped_paths.append(cropped_path)
+    return self.cropped_paths
+
+  def has_color_bar(self, row):
+    return row[2] == "1"
+
+  def is_excluded(self, path):
+    return str(path) in self.exclusions_set
+
+  def load_exclusions(self):
+    self.exclusions_set = set()
+    if self.exclusions_path is not None:
+      with open(self.exclusions_path, newline='') as csvfile:
+        csv_reader = csv.reader(csvfile)
+        next(csv_reader, None)
+        for row in csv_reader:
+          self.exclusions_set.add(row[0])
+
+  def crop_image(self, img_path, box_coords):
+    with Image.open(img_path) as img:
+      start_w, start_h = img.width, img.height
+      # Invert bounding box so that it is the region to retain
+      crop_coords = background_box(box_coords)
+      # convert crop coords from percentages to pixels
+      crop_pixels = norms_to_pixels(crop_coords, start_w, start_h)
+      # crop image
+      cropped = img.crop(tuple(crop_pixels))
+      # write image out to destination path
+      if cropped.mode != "RGB":
+        cropped = cropped.convert("RGB")
+      dest_path = self.cropped_image_output_path(img_path)
+      dest_path.parent.mkdir(parents=True, exist_ok=True)
+      cropped.save(dest_path, "JPEG", optimize=True, quality=80)
+      return dest_path
+
+  def cropped_image_output_path(self, img_path):
+    relative_path = img_path.relative_to(self.originals_base_path)
+    return self.output_path / relative_path

--- a/src/utils/segmentation_report_service.py
+++ b/src/utils/segmentation_report_service.py
@@ -5,7 +5,6 @@ from src.utils.json_utils import to_json
 from src.utils.bounding_box_utils import draw_bounding_boxes, is_problematic_box, get_box_coords
 from src.utils.common_utils import log
 from PIL import Image
-import json
 import shutil
 
 class SegmentationReportService:
@@ -44,19 +43,27 @@ class SegmentationReportService:
     destination_path = self.images_path / (str(norm_rel_path) + '.jpg')
     # Create parent directories for destination
     destination_path.parent.mkdir(parents=True, exist_ok=True)
-    boxes = self.get_box_coords(row)
+    boxes = []
+    coords = get_box_coords(row)
+    if coords != None:
+      boxes.append(coords)
+    # If the bounding box needed to be extended, then draw in the extended version of the box
+    extended_box = get_box_coords(row, index = 5)
+    if extended_box != None:
+      log(f'{row[0]} has an extended bounding box')
+      boxes.append(extended_box)
 
     draw_bounding_boxes(str(normalized_path), str(destination_path), [800, 800], boxes, retain_ratio = True)
     return destination_path
 
   def csv_to_data(self, row, image_path):
     rel_path = image_path.relative_to(self.output_path)
-    boxes = self.get_box_coords(row)
+    boxes = get_box_coords(row)
     return {
       'original' : row[0],
       'pred_class' : row[2],
       'pred_conf' : row[3],
-      'problem' : self.is_problematic_box(boxes),
+      'problem' : is_problematic_box(boxes),
       'image' : str(rel_path)
     }
 

--- a/src/utils/segmentation_report_service.py
+++ b/src/utils/segmentation_report_service.py
@@ -2,7 +2,7 @@ import csv
 import os
 from pathlib import Path
 from src.utils.json_utils import to_json
-from src.utils.bounding_box_utils import draw_bounding_boxes
+from src.utils.bounding_box_utils import draw_bounding_boxes, is_problematic_box, get_box_coords
 from src.utils.common_utils import log
 from PIL import Image
 import json
@@ -48,23 +48,6 @@ class SegmentationReportService:
 
     draw_bounding_boxes(str(normalized_path), str(destination_path), [800, 800], boxes, retain_ratio = True)
     return destination_path
-
-  # Box is problematic if 3 of its sides don't touch the edges of the image
-  def is_problematic_box(self, boxes):
-    if len(boxes) == 0:
-      return False
-    count = 0
-    count += boxes[0][0] == 0
-    count += boxes[0][1] == 0
-    count += boxes[0][2] == 1
-    count += boxes[0][3] == 1
-    return count != 3
-
-  def get_box_coords(self, row):
-    if row[4]:
-      box_coords = json.loads(row[4])
-      return [box_coords]
-    return []
 
   def csv_to_data(self, row, image_path):
     rel_path = image_path.relative_to(self.output_path)

--- a/src/utils/segmentation_workflow_service.py
+++ b/src/utils/segmentation_workflow_service.py
@@ -63,6 +63,7 @@ class SegmentationWorkflowService:
             if is_problematic_box(box_norms):
               try:
                 extended = extend_bounding_box_to_edges(box_norms)
+                print(f"   Problem detected with bounding box, extending to edges.")
               except InvalidBoundingBoxException as e:
                 print(e.message)
           csv_writer.writerow([path, normalized_path, predicted_class, "{:.4f}".format(top_score), box_norms, extended_box])

--- a/src/utils/segmentation_workflow_service.py
+++ b/src/utils/segmentation_workflow_service.py
@@ -6,7 +6,7 @@ from src.utils.image_segmenter import ImageSegmenter
 from src.utils.image_normalizer import ImageNormalizer
 from src.utils.progress_tracker import ProgressTracker
 from src.utils.segmentation_utils import round_box_to_edge, pixels_to_norms, norms_to_pixels
-from src.utils.bounding_box_utils import is_problematic_box, extend_bounding_box_to_edges
+from src.utils.bounding_box_utils import is_problematic_box, extend_bounding_box_to_edges, InvalidBoundingBoxException
 import torch
 from PIL import Image
 
@@ -62,7 +62,7 @@ class SegmentationWorkflowService:
             # If box isn't usable for cropping, try extending to edges
             if is_problematic_box(box_norms):
               try:
-                extended = extend_bounding_box_to_edges(box_norms)
+                extended_box = extend_bounding_box_to_edges(box_norms)
                 print(f"   Problem detected with bounding box, extending to edges.")
               except InvalidBoundingBoxException as e:
                 print(e.message)


### PR DESCRIPTION

* Adds crop.py for cropping color bars out of images based on segmentation model predictions, with option human feedback to skip certain images.
    * images are cropped by finding the "background box", which is the part of the image not in the color bar bounding box
    * Original images are not modified, the script produces new JPG derivatives of the originals to an output path.
    * New images are only produced for images which have been predicted to have color bars.
* Updates prediction workflow to produce an extra "extended" bounding box when the original prediction does not touch 3 sides of an image (it must do so to be usable for cropping). This extended bounding box is rendered in the HTML report as a green bounding box, while the actual prediction is red. Images with these extended bounding boxes are labeled as having problems in the report to make it easier to find and review them. 
    * The image will be cropped using in the extended bounding box, unless the image is excluded from cropping.
* Update readme with segmenter instructions