### PR TITLE
BXC-4542 - Performance improvements to support processing large directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,4 @@ logs/*.json
 .metaflow
 lightning_logs
 artifacts
+*-cache.txt

--- a/Pipfile
+++ b/Pipfile
@@ -11,6 +11,7 @@ pytorch-lightning = ">=2.1.0"
 metaflow = "*"
 scipi = ">= 1.10.0"
 numpy = ">= 1.24.0"
+psutil
 
 [dev-packages]
 pytest = "*"

--- a/classify.py
+++ b/classify.py
@@ -2,7 +2,7 @@ from src.utils.classifier_workflow_service import ClassifierWorkflowService
 from src.utils.classifier_config import ClassifierConfig
 import argparse
 from pathlib import Path
-from src.utils.common_utils import add_expanded_dir, recursive_paths_from_file_list
+from src.utils.cached_file_list import CachedFileList
 
 parser = argparse.ArgumentParser(description='Use a trained model to classify images in a directory. Normalized versions of the images will be produced if they are not already present')
 parser.add_argument('src_path', type=Path,
@@ -17,6 +17,8 @@ parser.add_argument('-l', '--file-list', action="store_true",
                     help='If provided, then the src_path will be treated as a text file containing a list of newline separated paths to normalize.'),
 parser.add_argument('-r', '--restart', action="store_true",
                     help='If provided, then the progress log and CSV report will be discarded and processing will start from the beginning'),
+parser.add_argument('--refresh', action="store_true",
+                    help='If provided, then the list of files to process will be refreshed from disk')
 
 
 args = parser.parse_args()
@@ -27,10 +29,8 @@ print(f'For types: {extensions}')
 
 config = ClassifierConfig(path=args.config)
 
-if args.file_list:
-  paths = recursive_paths_from_file_list(args.src_path, extensions)
-elif args.src_path.is_dir():
-  paths = add_expanded_dir(args.src_path, [], extensions)
+if args.file_list or args.src_path.is_dir():
+  paths = CachedFileList(args.src_path, extensions, args.refresh)
 else:
   paths = [args.src_path]
 

--- a/classify.py
+++ b/classify.py
@@ -28,9 +28,9 @@ print(f'For types: {extensions}')
 config = ClassifierConfig(path=args.config)
 
 if args.file_list:
-  paths = recursive_paths_from_file_list(args.src_path)
+  paths = recursive_paths_from_file_list(args.src_path, extensions)
 elif args.src_path.is_dir():
-  paths = add_expanded_dir(args.src_path, [])
+  paths = add_expanded_dir(args.src_path, [], extensions)
 else:
   paths = [args.src_path]
 

--- a/classify.py
+++ b/classify.py
@@ -36,7 +36,7 @@ if args.file_list:
   with open(args.src_path) as f:
     paths = []
     for line in f.read().splitlines():
-      path = Path(line)
+      path = Path(line.strip())
       if path.is_dir():
         add_expanded_dir(path, paths)
       else:

--- a/classify.py
+++ b/classify.py
@@ -2,6 +2,7 @@ from src.utils.classifier_workflow_service import ClassifierWorkflowService
 from src.utils.classifier_config import ClassifierConfig
 import argparse
 from pathlib import Path
+from src.utils.common_utils import add_expanded_dir, recursive_paths_from_file_list
 
 parser = argparse.ArgumentParser(description='Use a trained model to classify images in a directory. Normalized versions of the images will be produced if they are not already present')
 parser.add_argument('src_path', type=Path,
@@ -26,21 +27,8 @@ print(f'For types: {extensions}')
 
 config = ClassifierConfig(path=args.config)
 
-def add_expanded_dir(dir_path, paths):
-  for p in Path(dir_path).glob("**/*"):
-    if p.suffix in extensions:
-      paths.append(p)
-  return paths
-
 if args.file_list:
-  with open(args.src_path) as f:
-    paths = []
-    for line in f.read().splitlines():
-      path = Path(line.strip())
-      if path.is_dir():
-        add_expanded_dir(path, paths)
-      else:
-        paths.append(path)
+  paths = recursive_paths_from_file_list(args.src_path)
 elif args.src_path.is_dir():
   paths = add_expanded_dir(args.src_path, [])
 else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,6 +52,7 @@ Pillow==9.4.0
 platformdirs==3.2.0
 pluggy==1.0.0
 protobuf==4.22.3
+psutil==5.9.8
 pyasn1==0.5.0
 pyasn1-modules==0.3.0
 pycparser==2.21

--- a/segmenter_predict.py
+++ b/segmenter_predict.py
@@ -2,6 +2,7 @@ from src.utils.segmentation_workflow_service import SegmentationWorkflowService
 from src.utils.classifier_config import ClassifierConfig
 import argparse
 from pathlib import Path
+from src.utils.common_utils import add_expanded_dir, recursive_paths_from_file_list
 
 parser = argparse.ArgumentParser(description='Use a trained model to segment images in a directory. Normalized versions of the images will be produced if they are not already present')
 parser.add_argument('src_path', type=Path,
@@ -26,21 +27,8 @@ print(f'For types: {extensions}')
 
 config = ClassifierConfig(path=args.config)
 
-def add_expanded_dir(dir_path, paths):
-  for p in Path(dir_path).glob("**/*"):
-    if p.suffix in extensions:
-      paths.append(p)
-  return paths
-
 if args.file_list:
-  with open(args.src_path) as f:
-    paths = []
-    for line in f.read().splitlines():
-      path = Path(line.strip())
-      if path.is_dir():
-        add_expanded_dir(path, paths)
-      else:
-        paths.append(path)
+  paths = recursive_paths_from_file_list(args.src_path)
 elif args.src_path.is_dir():
   paths = add_expanded_dir(args.src_path, [])
 else:

--- a/segmenter_predict.py
+++ b/segmenter_predict.py
@@ -2,7 +2,7 @@ from src.utils.segmentation_workflow_service import SegmentationWorkflowService
 from src.utils.classifier_config import ClassifierConfig
 import argparse
 from pathlib import Path
-from src.utils.common_utils import add_expanded_dir, recursive_paths_from_file_list
+from src.utils.cached_file_list import CachedFileList
 
 parser = argparse.ArgumentParser(description='Use a trained model to segment images in a directory. Normalized versions of the images will be produced if they are not already present')
 parser.add_argument('src_path', type=Path,
@@ -12,11 +12,13 @@ parser.add_argument('report_path', type=Path,
 parser.add_argument('-c', '--config', type=Path,
                     help='If provided, config will be loaded from this file instead of commandline options')
 parser.add_argument('-e', '--extensions', default='tif,tiff,jp2,jpg,jpf,jpx,png',
-                    help='List of comma separated file extensions to filter by when operating on a directory. Default: tif,tiff,jp2,jpg,jpf,jpx,png'),
+                    help='List of comma separated file extensions to filter by when operating on a directory. Default: tif,tiff,jp2,jpg,jpf,jpx,png')
 parser.add_argument('-l', '--file-list', action="store_true",
-                    help='If provided, then the src_path will be treated as a text file containing a list of newline separated paths to normalize.'),
+                    help='If provided, then the src_path will be treated as a text file containing a list of newline separated paths to normalize.')
 parser.add_argument('-r', '--restart', action="store_true",
-                    help='If provided, then the progress log and CSV report will be discarded and processing will start from the beginning'),
+                    help='If provided, then the progress log and CSV report will be discarded and processing will start from the beginning')
+parser.add_argument('--refresh', action="store_true",
+                    help='If provided, then the list of files to process will be refreshed from disk')
 
 
 args = parser.parse_args()
@@ -27,10 +29,8 @@ print(f'For types: {extensions}')
 
 config = ClassifierConfig(path=args.config)
 
-if args.file_list:
-  paths = recursive_paths_from_file_list(args.src_path, extensions)
-elif args.src_path.is_dir():
-  paths = add_expanded_dir(args.src_path, [], extensions)
+if args.file_list or args.src_path.is_dir():
+  paths = CachedFileList(args.src_path, extensions, args.refresh)
 else:
   paths = [args.src_path]
 

--- a/segmenter_predict.py
+++ b/segmenter_predict.py
@@ -28,9 +28,9 @@ print(f'For types: {extensions}')
 config = ClassifierConfig(path=args.config)
 
 if args.file_list:
-  paths = recursive_paths_from_file_list(args.src_path)
+  paths = recursive_paths_from_file_list(args.src_path, extensions)
 elif args.src_path.is_dir():
-  paths = add_expanded_dir(args.src_path, [])
+  paths = add_expanded_dir(args.src_path, [], extensions)
 else:
   paths = [args.src_path]
 

--- a/segmenter_predict.py
+++ b/segmenter_predict.py
@@ -36,7 +36,7 @@ if args.file_list:
   with open(args.src_path) as f:
     paths = []
     for line in f.read().splitlines():
-      path = Path(line)
+      path = Path(line.strip())
       if path.is_dir():
         add_expanded_dir(path, paths)
       else:

--- a/segmenter_predict.py
+++ b/segmenter_predict.py
@@ -29,8 +29,10 @@ print(f'For types: {extensions}')
 
 config = ClassifierConfig(path=args.config)
 
+path = None
 if args.file_list or args.src_path.is_dir():
   paths = CachedFileList(args.src_path, extensions, args.refresh)
+  print(f'Found {len(paths)} paths for processing')
 else:
   paths = [args.src_path]
 

--- a/src/datasets/color_bar_segmentation_dataset.py
+++ b/src/datasets/color_bar_segmentation_dataset.py
@@ -29,15 +29,15 @@ class ColorBarSegmentationDataset(ColorBarDataset):
     super().__init__(config, image_paths, split)
 
   def normalize_image(path, max_dimension):
-    input_image = Image.open(path)
-    preprocess = transforms.Compose([
-        # Resize image to standard dimensions, no padding
-        transforms.Resize((max_dimension, max_dimension)),
-        transforms.ToTensor(),
-    ])
-    image_data = preprocess(input_image)
-    # Convert to a pytorchvision image
-    return tv_tensors.Image(image_data)
+    with Image.open(path) as input_image:
+      preprocess = transforms.Compose([
+          # Resize image to standard dimensions, no padding
+          transforms.Resize((max_dimension, max_dimension)),
+          transforms.ToTensor(),
+      ])
+      image_data = preprocess(input_image)
+      # Convert to a pytorchvision image
+      return tv_tensors.Image(image_data)
 
   # Must be overriden from parent class
   def __getitem__(self, index):

--- a/src/datasets/color_bar_segmentation_dataset.py
+++ b/src/datasets/color_bar_segmentation_dataset.py
@@ -1,6 +1,4 @@
-from numpy import zeros
 from src.datasets.color_bar_dataset import ColorBarDataset
-from src.utils.resnet_utils import load_for_resnet, load_mask_for_resnet
 from torchvision.transforms.functional import to_pil_image
 from torchvision.utils import draw_segmentation_masks
 from torchvision import tv_tensors
@@ -30,12 +28,12 @@ class ColorBarSegmentationDataset(ColorBarDataset):
 
   def normalize_image(path, max_dimension):
     with Image.open(path) as input_image:
-      preprocess = transforms.Compose([
-          # Resize image to standard dimensions, no padding
-          transforms.Resize((max_dimension, max_dimension)),
-          transforms.ToTensor(),
-      ])
-      image_data = preprocess(input_image)
+      w, h = input_image.size
+      # Only resize if the image is not already at the correct size
+      if w != max_dimension or h != max_dimension:
+        # Resizing image with PIL rather than torch for memory efficiency
+        input_image = input_image.resize((max_dimension, max_dimension))
+      image_data = transforms.ToTensor()(input_image)
       # Convert to a pytorchvision image
       return tv_tensors.Image(image_data)
 

--- a/src/datasets/color_bar_segmentation_dataset.py
+++ b/src/datasets/color_bar_segmentation_dataset.py
@@ -42,7 +42,6 @@ class ColorBarSegmentationDataset(ColorBarDataset):
   # Must be overriden from parent class
   def __getitem__(self, index):
     image_data = ColorBarSegmentationDataset.normalize_image(self.image_paths[index], self.config.max_dimension)
-    target = {}
     target = {
       'boxes' : tv_tensors.BoundingBoxes(self.boxes[index], format="XYXY", canvas_size=F.get_size(image_data)),
       'area' : box_area(self.boxes[index]),

--- a/src/systems/color_bar_segmentation_system.py
+++ b/src/systems/color_bar_segmentation_system.py
@@ -53,9 +53,7 @@ class ColorBarSegmentationSystem(pl.LightningModule):
     images, targets = batch
 
     # fasterrcnn takes both images and targets for training
-    print(f"==== Memory1: {torch.cuda.memory_allocated()} {torch.cuda.max_memory_allocated()}")
     loss_dict = self.model(images, targets)
-    return 1
     loss = self.calculate_model_loss(loss_dict)
     log(f'Training loss {loss}')
     self.log_dict({'loss': loss}, on_step=True, on_epoch=False, prog_bar=True, logger=True)

--- a/src/systems/color_bar_segmentation_system.py
+++ b/src/systems/color_bar_segmentation_system.py
@@ -53,7 +53,7 @@ class ColorBarSegmentationSystem(pl.LightningModule):
     images, targets = batch
 
     # fasterrcnn takes both images and targets for training
-    print(f"==== Memory1: {torch.cuda.memory_allocated() / torch.cuda.max_memory_allocated()}")
+    print(f"==== Memory1: {torch.cuda.memory_allocated()} {torch.cuda.max_memory_allocated()}")
     loss_dict = self.model(images, targets)
     return 1
     loss = self.calculate_model_loss(loss_dict)

--- a/src/systems/color_bar_segmentation_system.py
+++ b/src/systems/color_bar_segmentation_system.py
@@ -53,7 +53,9 @@ class ColorBarSegmentationSystem(pl.LightningModule):
     images, targets = batch
 
     # fasterrcnn takes both images and targets for training
+    print(f"==== Memory1: {torch.cuda.memory_allocated() / torch.cuda.max_memory_allocated()}")
     loss_dict = self.model(images, targets)
+    return 1
     loss = self.calculate_model_loss(loss_dict)
     log(f'Training loss {loss}')
     self.log_dict({'loss': loss}, on_step=True, on_epoch=False, prog_bar=True, logger=True)

--- a/src/tests/test_cached_file_list.py
+++ b/src/tests/test_cached_file_list.py
@@ -1,0 +1,113 @@
+from src.utils.cached_file_list import CachedFileList
+
+class TestCachedFileList:
+  def test_with_directory(self, tmp_path):
+    self.setup_test_dir(tmp_path)
+
+    subject = CachedFileList(self.base_path, { "jpg", "tiff" })
+    try:
+      assert len(subject) == 3
+      paths = self.collect_paths(subject)
+      assert len(paths) == 3
+      assert self.file_path1 in paths
+      assert self.file_path2 in paths
+      assert self.file_path3 in paths
+    finally:
+      subject.cache_path.unlink()
+
+  def test_with_directory_from_cache(self, tmp_path):
+    self.setup_test_dir(tmp_path)
+    subject = CachedFileList(self.base_path, { "jpg", "tiff" })
+    try:
+      assert len(subject) == 3
+
+      # Create an extra file that won't be picked up without a refresh
+      file_path5 = self.nested_path1 / "file5.jpg"
+      self.write_file(file_path5)
+      subject = CachedFileList(self.base_path, { "jpg", "tiff" })
+      paths = self.collect_paths(subject)
+      assert len(subject) == 3
+      assert not file_path5 in paths
+
+      # Initialize with refresh so that we pick up the extra item
+      subject = CachedFileList(self.base_path, { "jpg", "tiff" }, True)
+      paths = self.collect_paths(subject)
+      assert len(subject) == 4
+      assert file_path5 in paths
+    finally:
+      subject.cache_path.unlink()
+
+  def test_with_file_list(self, tmp_path):
+    self.setup_test_dir(tmp_path)
+    file_path5 = tmp_path / "file5.tiff"
+    self.write_file(file_path5)
+
+    file_list_path = tmp_path / "file_list.txt"
+    with open(file_list_path, "w") as file:
+      print(str(self.base_path), file=file)
+      print(str(file_path5), file=file)
+
+    subject = CachedFileList(file_list_path, { "jpg", "tiff" })
+    try:
+      assert len(subject) == 4
+      paths = self.collect_paths(subject)
+      assert len(paths) == 4
+      assert self.file_path1 in paths
+      assert self.file_path2 in paths
+      assert self.file_path3 in paths
+      assert file_path5 in paths
+    finally:
+      subject.cache_path.unlink()
+
+  def test_with_file_list_from_cache(self, tmp_path):
+    self.setup_test_dir(tmp_path)
+    file_path5 = tmp_path / "file5.tiff"
+    self.write_file(file_path5)
+
+    file_list_path = tmp_path / "file_list.txt"
+    with open(file_list_path, "w") as file:
+      print(str(self.base_path), file=file)
+      print(str(file_path5), file=file)
+
+    subject = CachedFileList(file_list_path, { "jpg", "tiff" })
+    try:
+      assert len(subject) == 4
+
+      # Create an extra file that won't be picked up without a refresh
+      file_path6 = self.nested_path1 / "file6.jpg"
+      self.write_file(file_path6)
+      subject = CachedFileList(file_list_path, { "jpg", "tiff" })
+      paths = self.collect_paths(subject)
+      assert len(subject) == 4
+      assert not file_path6 in paths
+
+      # Initialize with refresh so that we pick up the extra item
+      subject = CachedFileList(file_list_path, { "jpg", "tiff" }, True)
+      paths = self.collect_paths(subject)
+      assert len(subject) == 5
+      assert file_path6 in paths
+    finally:
+      subject.cache_path.unlink()
+
+  def setup_test_dir(self, tmp_path):
+    self.base_path = tmp_path / "test_base"
+    self.nested_path1 = self.base_path / "nested1"
+    self.nested_path2 = self.nested_path1 / "nested2"
+    self.nested_path2.mkdir(parents=True)
+    self.file_path1 = self.base_path / "file1.jpg"
+    self.file_path2 = self.base_path / "file2.tiff"
+    self.file_path3 = self.nested_path2 / "file3.jpg"
+    self.file_path4 = self.nested_path2 / "file4.txt"
+    self.write_file(self.file_path1)
+    self.write_file(self.file_path2)
+    self.write_file(self.file_path3)
+    
+  def write_file(self, file_path):
+    with open(file_path, "w") as text_file:
+      text_file.write(str(file_path))
+
+  def collect_paths(self, subject):
+    paths = []
+    for path in subject:
+      paths.append(path)
+    return paths

--- a/src/tests/test_cached_file_list.py
+++ b/src/tests/test_cached_file_list.py
@@ -4,7 +4,7 @@ class TestCachedFileList:
   def test_with_directory(self, tmp_path):
     self.setup_test_dir(tmp_path)
 
-    subject = CachedFileList(self.base_path, { "jpg", "tiff" })
+    subject = CachedFileList(self.base_path, { ".jpg", ".tiff" })
     try:
       assert len(subject) == 3
       paths = self.collect_paths(subject)
@@ -17,20 +17,20 @@ class TestCachedFileList:
 
   def test_with_directory_from_cache(self, tmp_path):
     self.setup_test_dir(tmp_path)
-    subject = CachedFileList(self.base_path, { "jpg", "tiff" })
+    subject = CachedFileList(self.base_path, { ".jpg", ".tiff" })
     try:
       assert len(subject) == 3
 
       # Create an extra file that won't be picked up without a refresh
       file_path5 = self.nested_path1 / "file5.jpg"
       self.write_file(file_path5)
-      subject = CachedFileList(self.base_path, { "jpg", "tiff" })
+      subject = CachedFileList(self.base_path, { ".jpg", ".tiff" })
       paths = self.collect_paths(subject)
       assert len(subject) == 3
       assert not file_path5 in paths
 
       # Initialize with refresh so that we pick up the extra item
-      subject = CachedFileList(self.base_path, { "jpg", "tiff" }, True)
+      subject = CachedFileList(self.base_path, { ".jpg", ".tiff" }, True)
       paths = self.collect_paths(subject)
       assert len(subject) == 4
       assert file_path5 in paths
@@ -47,7 +47,7 @@ class TestCachedFileList:
       print(str(self.base_path), file=file)
       print(str(file_path5), file=file)
 
-    subject = CachedFileList(file_list_path, { "jpg", "tiff" })
+    subject = CachedFileList(file_list_path, { ".jpg", ".tiff" })
     try:
       assert len(subject) == 4
       paths = self.collect_paths(subject)
@@ -69,20 +69,20 @@ class TestCachedFileList:
       print(str(self.base_path), file=file)
       print(str(file_path5), file=file)
 
-    subject = CachedFileList(file_list_path, { "jpg", "tiff" })
+    subject = CachedFileList(file_list_path, { ".jpg", ".tiff" })
     try:
       assert len(subject) == 4
 
       # Create an extra file that won't be picked up without a refresh
       file_path6 = self.nested_path1 / "file6.jpg"
       self.write_file(file_path6)
-      subject = CachedFileList(file_list_path, { "jpg", "tiff" })
+      subject = CachedFileList(file_list_path, { ".jpg", ".tiff" })
       paths = self.collect_paths(subject)
       assert len(subject) == 4
       assert not file_path6 in paths
 
       # Initialize with refresh so that we pick up the extra item
-      subject = CachedFileList(file_list_path, { "jpg", "tiff" }, True)
+      subject = CachedFileList(file_list_path, { ".jpg", ".tiff" }, True)
       paths = self.collect_paths(subject)
       assert len(subject) == 5
       assert file_path6 in paths

--- a/src/tests/test_image_normalizer.py
+++ b/src/tests/test_image_normalizer.py
@@ -176,5 +176,4 @@ class TestImageNormalizer:
     assert result.width == 565
     assert result.height == 224
     assert result.mode == 'RGB'
-    result.show()
   

--- a/src/tests/test_image_normalizer.py
+++ b/src/tests/test_image_normalizer.py
@@ -3,6 +3,7 @@ from PIL import Image
 from src.utils.image_normalizer import ImageNormalizer
 from src.utils.config import Config
 from pathlib import Path
+import shutil
 
 @pytest.fixture
 def config(tmp_path):
@@ -165,4 +166,15 @@ class TestImageNormalizer:
     result = Image.open(config.output_base_path / 'images/blue.jpg')
     assert result.width == 256
 
+  def test_process_malformed_jp2(self, config):
+    src_path = config.src_base_path / 'malformed.jp2'
+    shutil.copyfile(Path('fixtures/source_images/malformed.jp2'), src_path)
+    subject = ImageNormalizer(config)
+
+    subject.process(src_path)
+    result = Image.open(config.output_base_path / 'malformed.jpg')
+    assert result.width == 565
+    assert result.height == 224
+    assert result.mode == 'RGB'
+    result.show()
   

--- a/src/tests/test_segmentation_workflow_service.py
+++ b/src/tests/test_segmentation_workflow_service.py
@@ -16,6 +16,7 @@ def config(tmp_path):
   conf.predict_rounding_threshold = 0.5
   conf.max_dimension = 512
   conf.min_dimension = 512
+  conf.batch_size = 2
   return conf
 
 @pytest.fixture
@@ -27,8 +28,7 @@ def mock_model():
                               [  0.0000,   6.4033, 512.0000, 119.0521]]),
         'labels': torch.tensor([1, 1, 1]),
         'scores': torch.tensor([0.8920, 0.0657, 0.0568])
-      }]
-    value2 = [{
+      }, {
         'boxes': torch.zeros((0, 4), dtype=torch.float32),
         'labels': torch.tensor([], dtype=torch.int64),
         'scores': torch.tensor([], dtype=torch.float32)}]
@@ -38,7 +38,7 @@ def mock_model():
         'scores': torch.tensor([0.8920])
       }]
     # each call to model(image) will return a different set of outputs
-    model_mock.side_effect = [value1, value2, value3]
+    model_mock.side_effect = [value1, value3]
     return model_mock
 
 @pytest.fixture

--- a/src/utils/cached_file_list.py
+++ b/src/utils/cached_file_list.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+
+class CachedFileList(list):
+  """
+  List implementation which pulls entries in the list from a cache file on disk.
+  The cache will be populated on initialization if the cache does not already exist or
+  it has been requested to be refreshed.
+  Entries for the cache are taken from the provided file_path. If the file_path is
+  a directory, then all valid files in the directory will be added. If file_path is
+  a file, then each line in the file will be treated as a path to be added, where any
+  directories in the file will be expanded.
+  """
+  def __init__(self, file_path, extensions, refresh = False):
+    super().__init__()
+    self.file_path = file_path
+    self.extensions = extensions
+    self.cache_path = Path.cwd() / (file_path.stem + "-cache.txt")
+    if not self.cache_path.exists() or refresh:
+      self.populate_cache()
+    with open(self.cache_path, "r") as file:
+      self.total_entries = sum(1 for line in file)
+
+  def populate_cache(self):
+    if self.cache_path.exists():
+      self.cache_path.unlink()
+    with open(self.cache_path, "a") as file:
+      self.file = file
+      if self.file_path.is_dir():
+        # expand dir
+        self.add_expanded_dir(self.file_path)
+      else:
+        # parse as a file list
+        self.recursive_paths_from_file_list()
+
+  def add_expanded_dir(self, dir_path):
+    for p in Path(dir_path).glob("**/*"):
+      extension = p.suffix.strip(' .')
+      if extension in self.extensions:
+        print(str(p), file=self.file)
+
+  def recursive_paths_from_file_list(self):
+    print("Recursiving")
+    with open(self.file_path) as f:
+      for line in f.read().splitlines():
+        path = Path(line.strip())
+        print(f"With path {path}")
+        if path.is_dir():
+          self.add_expanded_dir(path)
+        else:
+          print(str(path), file=self.file)
+
+  def __iter__(self):
+    self.file = open(self.cache_path, "r")
+    return self
+
+  def __next__(self):
+    line = self.file.readline().strip()
+    if line == "":
+      self.file.close()
+      raise StopIteration
+    return Path(line)
+
+  def close(self):
+    if self.file:
+      self.file.close()
+
+  def __len__(self):
+    return self.total_entries

--- a/src/utils/cached_file_list.py
+++ b/src/utils/cached_file_list.py
@@ -39,12 +39,11 @@ class CachedFileList(list):
         print(str(p), file=self.file)
 
   def recursive_paths_from_file_list(self):
-    print("Recursiving")
     with open(self.file_path) as f:
       for line in f.read().splitlines():
         path = Path(line.strip())
-        print(f"With path {path}")
         if path.is_dir():
+          print(f"Expanding path {path}")
           self.add_expanded_dir(path)
         else:
           print(str(path), file=self.file)

--- a/src/utils/cached_file_list.py
+++ b/src/utils/cached_file_list.py
@@ -23,7 +23,7 @@ class CachedFileList(list):
   def populate_cache(self):
     if self.cache_path.exists():
       self.cache_path.unlink()
-    with open(self.cache_path, "a") as file:
+    with open(self.cache_path, "w") as file:
       self.file = file
       if self.file_path.is_dir():
         # expand dir
@@ -34,8 +34,7 @@ class CachedFileList(list):
 
   def add_expanded_dir(self, dir_path):
     for p in Path(dir_path).glob("**/*"):
-      extension = p.suffix.strip(' .')
-      if extension in self.extensions:
+      if p.suffix in self.extensions:
         print(str(p), file=self.file)
 
   def recursive_paths_from_file_list(self):

--- a/src/utils/classifier_config.py
+++ b/src/utils/classifier_config.py
@@ -11,6 +11,7 @@ class ClassifierConfig:
     self.output_base_path = Path('.')
     self.src_base_path = None
     self.progress_log_path = None
+    self.batch_size = None
     self.force = False
     if path != None:
       self.load_config(path)
@@ -28,4 +29,5 @@ class ClassifierConfig:
       self.output_base_path = Path(data['output_base_path']) if 'output_base_path' in data else None
       self.src_base_path = Path(data['src_base_path']) if 'src_base_path' in data else None
       self.progress_log_path = Path(data['progress_log_path']) if 'progress_log_path' in data else None
+      self.batch_size = data.get('batch_size', 10)
       self.force = bool(data.get('force', False))

--- a/src/utils/classifier_config.py
+++ b/src/utils/classifier_config.py
@@ -24,7 +24,7 @@ class ClassifierConfig:
       self.model_path = Path(data['model_path']) if 'model_path' in data else None
       # Max dimension size which images will be normalized to
       self.max_dimension = data.get('max_dimension', None)
-      self.min_dimension = data.get('min_dimension', None)
+      self.min_dimension = data.get('min_dimension', self.max_dimension)
       self.output_base_path = Path(data['output_base_path']) if 'output_base_path' in data else None
       self.src_base_path = Path(data['src_base_path']) if 'src_base_path' in data else None
       self.progress_log_path = Path(data['progress_log_path']) if 'progress_log_path' in data else None

--- a/src/utils/color_bar_model_trainer.py
+++ b/src/utils/color_bar_model_trainer.py
@@ -12,6 +12,7 @@ from src.datasets.color_bar_data_module import ColorBarDataModule
 from src.systems.color_bar_classifying_system import ColorBarClassifyingSystem
 from src.utils.json_utils import to_json
 from src.utils.common_utils import log
+import torch
 
 class ColorBarModelTrainer:
   def init_system(self, config_path):

--- a/src/utils/color_bar_model_trainer.py
+++ b/src/utils/color_bar_model_trainer.py
@@ -42,6 +42,7 @@ class ColorBarModelTrainer:
     )
 
     self.trainer = Trainer(
+      profiler="advanced",
       num_sanity_val_steps = 0,
       max_epochs = self.config.max_epochs,
       log_every_n_steps = self.config.log_every_n_steps,

--- a/src/utils/color_bar_model_trainer.py
+++ b/src/utils/color_bar_model_trainer.py
@@ -28,7 +28,7 @@ class ColorBarModelTrainer:
     # a PyTorch Lightning system wraps around model logic
     self.system = self.config.system_class(self.config)
     log(f'Initializing system, saving to {self.config.save_dir}')
-    print(f"==== MemoryI: {torch.cuda.memory_allocated() / torch.cuda.max_memory_allocated()}")
+    print(f"==== MemoryI: {torch.cuda.memory_allocated()} {torch.cuda.max_memory_allocated()}")
 
     # a callback to save best model weights
     checkpoint_callback = ModelCheckpoint(
@@ -50,7 +50,7 @@ class ColorBarModelTrainer:
       callbacks = [checkpoint_callback])
 
   def train_model(self):
-    print(f"==== Memory0: {torch.cuda.memory_allocated() / torch.cuda.max_memory_allocated()}")
+    print(f"==== Memory0: {torch.cuda.memory_allocated()} {torch.cuda.max_memory_allocated()}")
     self.trainer.fit(self.system, self.dm)
 
   def validation_evaluation(self):

--- a/src/utils/color_bar_model_trainer.py
+++ b/src/utils/color_bar_model_trainer.py
@@ -12,7 +12,6 @@ from src.datasets.color_bar_data_module import ColorBarDataModule
 from src.systems.color_bar_classifying_system import ColorBarClassifyingSystem
 from src.utils.json_utils import to_json
 from src.utils.common_utils import log
-import torch
 
 class ColorBarModelTrainer:
   def init_system(self, config_path):
@@ -28,7 +27,6 @@ class ColorBarModelTrainer:
     # a PyTorch Lightning system wraps around model logic
     self.system = self.config.system_class(self.config)
     log(f'Initializing system, saving to {self.config.save_dir}')
-    print(f"==== MemoryI: {torch.cuda.memory_allocated()} {torch.cuda.max_memory_allocated()}")
 
     # a callback to save best model weights
     checkpoint_callback = ModelCheckpoint(
@@ -51,7 +49,6 @@ class ColorBarModelTrainer:
       callbacks = [checkpoint_callback])
 
   def train_model(self):
-    print(f"==== Memory0: {torch.cuda.memory_allocated()} {torch.cuda.max_memory_allocated()}")
     self.trainer.fit(self.system, self.dm)
 
   def validation_evaluation(self):

--- a/src/utils/color_bar_model_trainer.py
+++ b/src/utils/color_bar_model_trainer.py
@@ -27,6 +27,7 @@ class ColorBarModelTrainer:
     # a PyTorch Lightning system wraps around model logic
     self.system = self.config.system_class(self.config)
     log(f'Initializing system, saving to {self.config.save_dir}')
+    print(f"==== MemoryI: {torch.cuda.memory_allocated() / torch.cuda.max_memory_allocated()}")
 
     # a callback to save best model weights
     checkpoint_callback = ModelCheckpoint(
@@ -48,6 +49,7 @@ class ColorBarModelTrainer:
       callbacks = [checkpoint_callback])
 
   def train_model(self):
+    print(f"==== Memory0: {torch.cuda.memory_allocated() / torch.cuda.max_memory_allocated()}")
     self.trainer.fit(self.system, self.dm)
 
   def validation_evaluation(self):

--- a/src/utils/common_utils.py
+++ b/src/utils/common_utils.py
@@ -1,6 +1,23 @@
 from datetime import datetime
 
-_all__ = ["log"]
+_all__ = ["log", "add_expanded_dir", "recursive_paths_from_file_list"]
 
 def log(message):
   print(f'{datetime.now().isoformat()} {message}')
+
+def add_expanded_dir(dir_path, paths):
+  for p in Path(dir_path).glob("**/*"):
+    if p.suffix in extensions:
+      paths.append(p)
+  return paths
+
+def recursive_paths_from_file_list(file_list_path):
+  with open(file_list_path) as f:
+    paths = []
+    for line in f.read().splitlines():
+      path = Path(line.strip())
+      if path.is_dir():
+        add_expanded_dir(path, paths)
+      else:
+        paths.append(path)
+    return paths

--- a/src/utils/common_utils.py
+++ b/src/utils/common_utils.py
@@ -1,17 +1,18 @@
 from datetime import datetime
+from pathlib import Path
 
 _all__ = ["log", "add_expanded_dir", "recursive_paths_from_file_list"]
 
 def log(message):
   print(f'{datetime.now().isoformat()} {message}')
 
-def add_expanded_dir(dir_path, paths):
+def add_expanded_dir(dir_path, paths, extensions):
   for p in Path(dir_path).glob("**/*"):
     if p.suffix in extensions:
       paths.append(p)
   return paths
 
-def recursive_paths_from_file_list(file_list_path):
+def recursive_paths_from_file_list(file_list_path, extensions):
   with open(file_list_path) as f:
     paths = []
     for line in f.read().splitlines():

--- a/src/utils/common_utils.py
+++ b/src/utils/common_utils.py
@@ -1,24 +1,7 @@
 from datetime import datetime
 from pathlib import Path
 
-_all__ = ["log", "add_expanded_dir", "recursive_paths_from_file_list"]
+_all__ = ["log"]
 
 def log(message):
   print(f'{datetime.now().isoformat()} {message}')
-
-def add_expanded_dir(dir_path, paths, extensions):
-  for p in Path(dir_path).glob("**/*"):
-    if p.suffix in extensions:
-      paths.append(p)
-  return paths
-
-def recursive_paths_from_file_list(file_list_path, extensions):
-  with open(file_list_path) as f:
-    paths = []
-    for line in f.read().splitlines():
-      path = Path(line.strip())
-      if path.is_dir():
-        add_expanded_dir(path, paths, extensions)
-      else:
-        paths.append(path)
-    return paths

--- a/src/utils/common_utils.py
+++ b/src/utils/common_utils.py
@@ -18,7 +18,7 @@ def recursive_paths_from_file_list(file_list_path, extensions):
     for line in f.read().splitlines():
       path = Path(line.strip())
       if path.is_dir():
-        add_expanded_dir(path, paths)
+        add_expanded_dir(path, paths, extensions)
       else:
         paths.append(path)
     return paths

--- a/src/utils/cropping_workflow_service.py
+++ b/src/utils/cropping_workflow_service.py
@@ -6,7 +6,7 @@ from src.utils.image_segmenter import ImageSegmenter
 from src.utils.segmentation_utils import round_box_to_edge, pixels_to_norms, norms_to_pixels, background_box
 from src.utils.bounding_box_utils import is_problematic_box, get_box_coords, number_sides_at_image_edge
 import torch
-from PIL import Image
+from PIL import Image, ImageFile
 from src.utils.common_utils import log
 
 # Service which accepts a prediction CSV, and generates cropped versions of listed original
@@ -19,6 +19,8 @@ class CroppingWorkflowService:
     self.exclusions_path = exclusions_path
     self.originals_base_path = originals_base_path.resolve()
     self.cropped_paths = []
+    # Prevent pillow from throwing an exception when reading truncated images
+    ImageFile.LOAD_TRUNCATED_IMAGES = True
   
   def process(self):
     # Load exclusion paths

--- a/src/utils/image_normalizer.py
+++ b/src/utils/image_normalizer.py
@@ -23,17 +23,18 @@ class ImageNormalizer:
       return output_path
 
 
-    print(f"Memoryn1: {psutil.virtual_memory().percent}")
+    print(f"Memoryn1: {psutil.virtual_memory()}")
     with Image.open(path) as img:
+      print(f"Memoryn2: {psutil.virtual_memory()}")
       if img.mode != "RGB":
         img = img.convert("RGB")
-      print(f"Memoryn2: {psutil.virtual_memory().percent}")
+      print(f"Memoryn3: {psutil.virtual_memory()}")
       img = self.resize(img)
-      print(f"Memoryn3: {psutil.virtual_memory().percent}")
+      print(f"Memoryn4: {psutil.virtual_memory()}")
       # construct path to write to, then save the file
       output_path.parent.mkdir(parents=True, exist_ok=True)
       img.save(output_path, "JPEG", optimize=True, quality=80)
-      print(f"Memoryn4: {psutil.virtual_memory().percent}")
+      print(f"Memoryn5: {psutil.virtual_memory().percent}")
     return output_path
 
   # Constructs an output path based on the input path and configured base paths.

--- a/src/utils/image_normalizer.py
+++ b/src/utils/image_normalizer.py
@@ -1,6 +1,7 @@
 from PIL import Image, ImageFile
 from pathlib import Path
 import logging
+import psutil
 
 # Utility for normalizing images based on a configuration.
 # Currently normalizes all files to JPGs
@@ -21,13 +22,18 @@ class ImageNormalizer:
       logging.info('Derivative already exists, skipping %s', path)
       return output_path
 
+
+    print(f"Memoryn1: {psutil.virtual_memory().percent}")
     with Image.open(path) as img:
       if img.mode != "RGB":
         img = img.convert("RGB")
+      print(f"Memoryn2: {psutil.virtual_memory().percent}")
       img = self.resize(img)
+      print(f"Memoryn3: {psutil.virtual_memory().percent}")
       # construct path to write to, then save the file
       output_path.parent.mkdir(parents=True, exist_ok=True)
       img.save(output_path, "JPEG", optimize=True, quality=80)
+      print(f"Memoryn4: {psutil.virtual_memory().percent}")
     return output_path
 
   # Constructs an output path based on the input path and configured base paths.

--- a/src/utils/image_normalizer.py
+++ b/src/utils/image_normalizer.py
@@ -25,11 +25,11 @@ class ImageNormalizer:
 
     print(f"Memoryn1: {psutil.virtual_memory()}")
     with Image.open(path) as img:
-      print(f"Memoryn2: {psutil.virtual_memory()}")
+      print(f"Memoryr2: {psutil.virtual_memory()}")
+      img = self.resize(img)
+      print(f"Memoryn3: {psutil.virtual_memory()}")
       if img.mode != "RGB":
         img = img.convert("RGB")
-      print(f"Memoryn3: {psutil.virtual_memory()}")
-      img = self.resize(img)
       print(f"Memoryn4: {psutil.virtual_memory()}")
       # construct path to write to, then save the file
       output_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/utils/image_normalizer.py
+++ b/src/utils/image_normalizer.py
@@ -1,4 +1,4 @@
-from PIL import Image
+from PIL import Image, ImageFile
 from pathlib import Path
 import logging
 
@@ -8,6 +8,8 @@ class ImageNormalizer:
   def __init__(self, config):
     # Disable DecompressionBombError since many of our images are huge
     Image.MAX_IMAGE_PIXELS = None
+    # Prevent pillow from throwing an exception when reading truncated images
+    ImageFile.LOAD_TRUNCATED_IMAGES = True
     self.config = config
 
   # Normalize an image to the expected configuration, saving the normalized version to an configured output path

--- a/src/utils/image_normalizer.py
+++ b/src/utils/image_normalizer.py
@@ -1,7 +1,6 @@
 from PIL import Image, ImageFile
 from pathlib import Path
 import logging
-import psutil
 
 # Utility for normalizing images based on a configuration.
 # Currently normalizes all files to JPGs
@@ -22,19 +21,14 @@ class ImageNormalizer:
       logging.info('Derivative already exists, skipping %s', path)
       return output_path
 
-
-    print(f"Memoryn1: {psutil.virtual_memory()}")
     with Image.open(path) as img:
-      print(f"Memoryr2: {psutil.virtual_memory()}")
+      # Resize before converting, so that we are working with a smaller image to keep down memory usage
       img = self.resize(img)
-      print(f"Memoryn3: {psutil.virtual_memory()}")
       if img.mode != "RGB":
         img = img.convert("RGB")
-      print(f"Memoryn4: {psutil.virtual_memory()}")
       # construct path to write to, then save the file
       output_path.parent.mkdir(parents=True, exist_ok=True)
       img.save(output_path, "JPEG", optimize=True, quality=80)
-      print(f"Memoryn5: {psutil.virtual_memory().percent}")
     return output_path
 
   # Constructs an output path based on the input path and configured base paths.

--- a/src/utils/segmentation_workflow_service.py
+++ b/src/utils/segmentation_workflow_service.py
@@ -56,6 +56,7 @@ class SegmentationWorkflowService:
         except BaseException as e:
           print(f'Failed to process {path}: {e}')
           print(traceback.format_exc())
+
         # Accumulated a batch worth of images, or this is the final image
         if len(batch_norm_paths) == self.config.batch_size or idx == (len(paths) - 1):
           top_predictions, top_scores = self.segmenter.predict(batch_norm_paths)

--- a/src/utils/segmentation_workflow_service.py
+++ b/src/utils/segmentation_workflow_service.py
@@ -15,6 +15,7 @@ from PIL import Image
 # The outcome is written to a CSV file at the provided report_path.
 class SegmentationWorkflowService:
   CSV_HEADERS = ['original_path', 'normalized_path', 'predicted_class', 'predicted_conf', 'bounding_box', 'extended_box']
+  BATCH_SIZE = 10
 
   def __init__(self, config, report_path, restart = False):
     self.config = config
@@ -38,42 +39,59 @@ class SegmentationWorkflowService:
       if is_new_file:
         csv_writer.writerow(self.CSV_HEADERS)
 
+      batch_orig_paths = []
+      batch_norm_paths = []
       for idx, path in enumerate(paths):
         if self.progress_tracker.is_complete(path):
           print(f"Skipping {idx + 1} of {total}: {path}")
           continue
 
         print(f"Processing {idx + 1} of {total}: {path}")
+        path = path.resolve()
+        batch_orig_paths.append(path)
         try:
-          path = path.resolve()
-          normalized_path = self.normalizer.process(path)
-          top_predicted, top_score = self.segmenter.predict(normalized_path)
-          box_coords = top_predicted['boxes']
-          box_norms = None
-          extended_box = None
-          predicted_class = 0
-          orig_box, norm_box = None, None
-          # If a bounding box was returned, then convert coordinates to percentages and round to edges
-          if box_coords.shape[0] == 1:
-            predicted_class = 1
-            box_coords = box_coords[0].detach().numpy()
-            box_norms = self.normalize_coords(box_coords)
-            # Round the bounding box to the edges of the image if they are close
-            box_norms = list(round_box_to_edge(box_norms))
-            # If box isn't usable for cropping, try extending to edges
-            if is_problematic_box(box_norms):
-              try:
-                extended_box = extend_bounding_box_to_edges(box_norms)
-                print(f"   Problem detected with bounding box, extending to edges.")
-              except InvalidBoundingBoxException as e:
-                print(e.message)
-          csv_writer.writerow([path, normalized_path, predicted_class, "{:.4f}".format(top_score), box_norms, extended_box])
-          self.progress_tracker.record_completed(path)
+          batch_norm_paths.append(self.normalizer.process(path))
         except (KeyboardInterrupt, SystemExit) as e:
           exit(1)
         except BaseException as e:
           print(f'Failed to process {path}: {e}')
           print(traceback.format_exc())
+        # Accumulated a batch worth of images, or this is the final image
+        if len(batch_norm_paths) == self.config.batch_size or idx == (len(paths) - 1):
+          top_predictions, top_scores = self.segmenter.predict(batch_norm_paths)
+          for batch_idx, orig_path in enumerate(batch_orig_paths):
+            normalized_path = batch_norm_paths[batch_idx]
+            top_predicted = top_predictions[batch_idx]
+            top_score = top_scores[batch_idx]
+            try:
+              box_coords = top_predicted['boxes']
+              box_norms = None
+              extended_box = None
+              predicted_class = 0
+              orig_box, norm_box = None, None
+              # If a bounding box was returned, then convert coordinates to percentages and round to edges
+              if box_coords.shape[0] == 1:
+                predicted_class = 1
+                box_coords = box_coords[0].detach().numpy()
+                box_norms = self.normalize_coords(box_coords)
+                # Round the bounding box to the edges of the image if they are close
+                box_norms = list(round_box_to_edge(box_norms))
+                # If box isn't usable for cropping, try extending to edges
+                if is_problematic_box(box_norms):
+                  try:
+                    extended_box = extend_bounding_box_to_edges(box_norms)
+                    print(f"   Problem detected with bounding box, extending to edges.")
+                  except InvalidBoundingBoxException as e:
+                    print(e.message)
+              csv_writer.writerow([orig_path, normalized_path, predicted_class, "{:.4f}".format(top_score), box_norms, extended_box])
+              self.progress_tracker.record_completed(orig_path)
+            except (KeyboardInterrupt, SystemExit) as e:
+              exit(1)
+            except BaseException as e:
+              print(f'Failed to process {orig_path}: {e}')
+              print(traceback.format_exc())
+          batch_orig_paths = []
+          batch_norm_paths = []
 
   def normalize_coords(self, box_coords):
     return pixels_to_norms(box_coords, self.config.max_dimension, self.config.max_dimension)

--- a/src/utils/segmentation_workflow_service.py
+++ b/src/utils/segmentation_workflow_service.py
@@ -9,6 +9,7 @@ from src.utils.segmentation_utils import round_box_to_edge, pixels_to_norms, nor
 from src.utils.bounding_box_utils import is_problematic_box, extend_bounding_box_to_edges, InvalidBoundingBoxException
 import torch
 from PIL import Image
+import psutil
 
 # Service which accepts a list of image original files, then performs object
 # detection/segmentation to make predictions on normalized versions of those images.
@@ -52,15 +53,18 @@ class SegmentationWorkflowService:
           continue
 
         print(f"Processing {idx + 1} of {total}: {path} {len(batch_norm_paths)} {len(batch_orig_paths)} / {batch_size}")
+        print(f"Memory1: {psutil.virtual_memory().percent}")
         path = path.resolve()
         try:
           batch_norm_paths.append(self.normalizer.process(path))
+          print(f"Memory2: {psutil.virtual_memory().percent}")
           batch_orig_paths.append(path)
         except (KeyboardInterrupt, SystemExit) as e:
           exit(1)
         except BaseException as e:
           print(f'Failed to process {path}: {e}')
           print(traceback.format_exc())
+        print(f"Memory3: {psutil.virtual_memory().percent}")
 
         # Accumulated a batch worth of images, or this is the final image
         if len(batch_orig_paths) >= batch_size or idx == (len(paths) - 1):

--- a/src/utils/segmentation_workflow_service.py
+++ b/src/utils/segmentation_workflow_service.py
@@ -32,6 +32,7 @@ class SegmentationWorkflowService:
   def process(self, paths):
     total = len(paths)
     is_new_file = not Path.exists(self.report_path) or os.path.getsize(self.report_path) == 0
+    batch_size = int(self.config.batch_size)
 
     with open(self.report_path, "a", newline="") as csv_file:
       csv_writer = csv.writer(csv_file)
@@ -46,7 +47,7 @@ class SegmentationWorkflowService:
           print(f"Skipping {idx + 1} of {total}: {path}")
           continue
 
-        print(f"Processing {idx + 1} of {total}: {path} {len(batch_orig_paths)} / {self.config.batch_size}")
+        print(f"Processing {idx + 1} of {total}: {path} {len(batch_norm_paths)} {len(batch_orig_paths)} / {batch_size}")
         path = path.resolve()
         batch_orig_paths.append(path)
         try:
@@ -58,7 +59,7 @@ class SegmentationWorkflowService:
           print(traceback.format_exc())
 
         # Accumulated a batch worth of images, or this is the final image
-        if len(batch_norm_paths) == self.config.batch_size or idx == (len(paths) - 1):
+        if len(batch_orig_paths) >= batch_size or idx == (len(paths) - 1):
           top_predictions, top_scores = self.segmenter.predict(batch_norm_paths)
           for batch_idx, orig_path in enumerate(batch_orig_paths):
             normalized_path = batch_norm_paths[batch_idx]

--- a/src/utils/segmentation_workflow_service.py
+++ b/src/utils/segmentation_workflow_service.py
@@ -9,7 +9,6 @@ from src.utils.segmentation_utils import round_box_to_edge, pixels_to_norms, nor
 from src.utils.bounding_box_utils import is_problematic_box, extend_bounding_box_to_edges, InvalidBoundingBoxException
 import torch
 from PIL import Image
-import psutil
 
 # Service which accepts a list of image original files, then performs object
 # detection/segmentation to make predictions on normalized versions of those images.
@@ -53,18 +52,15 @@ class SegmentationWorkflowService:
           continue
 
         print(f"Processing {idx + 1} of {total}: {path} {len(batch_norm_paths)} {len(batch_orig_paths)} / {batch_size}")
-        print(f"Memory1: {psutil.virtual_memory()}")
         path = path.resolve()
         try:
           batch_norm_paths.append(self.normalizer.process(path))
-          print(f"Memory2: {psutil.virtual_memory()}")
           batch_orig_paths.append(path)
         except (KeyboardInterrupt, SystemExit) as e:
           exit(1)
         except BaseException as e:
           print(f'Failed to process {path}: {e}')
           print(traceback.format_exc())
-        print(f"Memory3: {psutil.virtual_memory()}")
 
         # Accumulated a batch worth of images, or this is the final image
         if len(batch_orig_paths) >= batch_size or idx == (len(paths) - 1):

--- a/src/utils/segmentation_workflow_service.py
+++ b/src/utils/segmentation_workflow_service.py
@@ -53,18 +53,18 @@ class SegmentationWorkflowService:
           continue
 
         print(f"Processing {idx + 1} of {total}: {path} {len(batch_norm_paths)} {len(batch_orig_paths)} / {batch_size}")
-        print(f"Memory1: {psutil.virtual_memory().percent}")
+        print(f"Memory1: {psutil.virtual_memory()}")
         path = path.resolve()
         try:
           batch_norm_paths.append(self.normalizer.process(path))
-          print(f"Memory2: {psutil.virtual_memory().percent}")
+          print(f"Memory2: {psutil.virtual_memory()}")
           batch_orig_paths.append(path)
         except (KeyboardInterrupt, SystemExit) as e:
           exit(1)
         except BaseException as e:
           print(f'Failed to process {path}: {e}')
           print(traceback.format_exc())
-        print(f"Memory3: {psutil.virtual_memory().percent}")
+        print(f"Memory3: {psutil.virtual_memory()}")
 
         # Accumulated a batch worth of images, or this is the final image
         if len(batch_orig_paths) >= batch_size or idx == (len(paths) - 1):

--- a/src/utils/segmentation_workflow_service.py
+++ b/src/utils/segmentation_workflow_service.py
@@ -46,6 +46,10 @@ class SegmentationWorkflowService:
         if self.progress_tracker.is_complete(path):
           print(f"Skipping {idx + 1} of {total}: {path}")
           continue
+        if self.unprocessable_filename(path):
+          print(f"Skipping {idx + 1} of {total} due to filename: {path}")
+          self.progress_tracker.record_completed(path)
+          continue
 
         print(f"Processing {idx + 1} of {total}: {path} {len(batch_norm_paths)} {len(batch_orig_paths)} / {batch_size}")
         path = path.resolve()
@@ -97,3 +101,7 @@ class SegmentationWorkflowService:
 
   def normalize_coords(self, box_coords):
     return pixels_to_norms(box_coords, self.config.max_dimension, self.config.max_dimension)
+
+  def unprocessable_filename(self, path):
+    # ignore sidecar files
+    return path.stem.startswith("._")

--- a/src/utils/segmentation_workflow_service.py
+++ b/src/utils/segmentation_workflow_service.py
@@ -46,7 +46,7 @@ class SegmentationWorkflowService:
           print(f"Skipping {idx + 1} of {total}: {path}")
           continue
 
-        print(f"Processing {idx + 1} of {total}: {path}")
+        print(f"Processing {idx + 1} of {total}: {path} {len(batch_orig_paths)} / {self.config.batch_size}")
         path = path.resolve()
         batch_orig_paths.append(path)
         try:

--- a/src/utils/segmentation_workflow_service.py
+++ b/src/utils/segmentation_workflow_service.py
@@ -49,9 +49,9 @@ class SegmentationWorkflowService:
 
         print(f"Processing {idx + 1} of {total}: {path} {len(batch_norm_paths)} {len(batch_orig_paths)} / {batch_size}")
         path = path.resolve()
-        batch_orig_paths.append(path)
         try:
           batch_norm_paths.append(self.normalizer.process(path))
+          batch_orig_paths.append(path)
         except (KeyboardInterrupt, SystemExit) as e:
           exit(1)
         except BaseException as e:


### PR DESCRIPTION

* Submit images for prediction with the model in batches instead of one by one to speed up processing
* Resize images (with PIL) before converting to RGB, which significantly cuts down on memory usage for large images
* Adds `CachedFileList` which is a type of List which writes lists of files to a cache file, and then reads from that file to get the next file path for processing. This allows for loading large lists of files once in case of resuming the script (listing the files can take a pretty long time), and avoids needing to keep hundreds of thousands of paths in memory
* Add config option to tell pillow to process "truncated" images, otherwise it throws an error and fails.
* Skip processing of "._" sidecar files, since they are not actually images
* Some other minor cleanup